### PR TITLE
Added missing code type of corrected the incorrect ones.

### DIFF
--- a/develop/add-a-verified-domain-for-a-customer.md
+++ b/develop/add-a-verified-domain-for-a-customer.md
@@ -176,7 +176,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 201 Created
 Content-Length: 206
 Content-Type: application/json; charset=utf-8

--- a/develop/change-the-quantity-of-a-subscription.md
+++ b/develop/change-the-quantity-of-a-subscription.md
@@ -129,7 +129,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 PATCH https://api.partnercenter.microsoft.com/v1/customers/<customer-tenant-id>/subscriptions/<subscriptionID> HTTP/1.1
 Authorization: Bearer <token>
 Accept: application/json

--- a/develop/check-inventory.md
+++ b/develop/check-inventory.md
@@ -121,7 +121,7 @@ This method returns the following error codes:
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 1021
 Content-Type: application/json; charset=utf-8

--- a/develop/check-which-licenses-are-assigned-to-a-user.md
+++ b/develop/check-which-licenses-are-assigned-to-a-user.md
@@ -94,7 +94,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 3883
 Content-Type: application/json; charset=utf-8

--- a/develop/checkout-a-cart.md
+++ b/develop/checkout-a-cart.md
@@ -103,7 +103,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 201 Created
 Content-Length: 764
 Content-Type: application/json; charset=utf-8

--- a/develop/confirm-customer-consent.md
+++ b/develop/confirm-customer-consent.md
@@ -172,7 +172,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 201 Created
 Content-Length: 261
 Content-Type: application/json

--- a/develop/convert-a-trial-subscription-to-paid.md
+++ b/develop/convert-a-trial-subscription-to-paid.md
@@ -162,7 +162,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 211
 Content-Type: application/json; charset=utf-8

--- a/develop/create-a-cart.md
+++ b/develop/create-a-cart.md
@@ -165,7 +165,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 201 Created
 Content-Length: 764
 Content-Type: application/json; charset=utf-8

--- a/develop/create-a-customer-for-an-indirect-reseller.md
+++ b/develop/create-a-customer-for-an-indirect-reseller.md
@@ -198,7 +198,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 201 Created
 Content-Length: 1085
 Content-Type: application/json; charset=utf-8

--- a/develop/create-a-customer.md
+++ b/develop/create-a-customer.md
@@ -182,7 +182,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 201 Created
 Content-Length: 834
 Content-Type: application/json; charset=utf-8

--- a/develop/create-a-new-configuration-policy-for-the-specified-customer.md
+++ b/develop/create-a-new-configuration-policy-for-the-specified-customer.md
@@ -120,7 +120,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 404
 Content-Type: application/json; charset=utf-8

--- a/develop/create-a-service-request-.md
+++ b/develop/create-a-service-request-.md
@@ -155,7 +155,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 201 Created
 Content-Length: 721
 Content-Type: application/json; charset=utf-8

--- a/develop/create-an-order-for-a-customer-of-an-indirect-reseller.md
+++ b/develop/create-an-order-for-a-customer-of-an-indirect-reseller.md
@@ -300,7 +300,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 201 Created
 Content-Length: 831
 Content-Type: application/json; charset=utf-8

--- a/develop/create-an-order.md
+++ b/develop/create-an-order.md
@@ -189,7 +189,7 @@ This method returns the following error codes:
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 201 Created
 Content-Length: 788
 Content-Type: application/json; charset=utf-8

--- a/develop/create-user-accounts-for-a-customer.md
+++ b/develop/create-user-accounts-for-a-customer.md
@@ -114,7 +114,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 31942
 Content-Type: application/json

--- a/develop/delete-a-configuration-policy-for-the-specified-customer.md
+++ b/develop/delete-a-configuration-policy-for-the-specified-customer.md
@@ -96,7 +96,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 204 No Content
 Content-Length: 0
 MS-CorrelationId: cee5caf4-c322-4baa-b1d7-e94afb9891a4
@@ -105,11 +105,3 @@ MS-CV: YrLe3w6BbUSMt1fi.0
 MS-ServerId: 030020344
 Date: Tue, 25 Jul 2017 18:10:41 GMT
 ```
-
- 
-
- 
-
-
-
-

--- a/develop/delete-a-customer-account-from-the-integration-sandbox.md
+++ b/develop/delete-a-customer-account-from-the-integration-sandbox.md
@@ -135,18 +135,10 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 204 No Content
 Content-Length: 0
 MS-CorrelationId: 1438ea3d-b515-45c7-9ec1-27ee0cc8e6bd
 MS-RequestId: 655890ba-4d2b-4d09-a95f-4ea1348686a5
 Date: Wed, 16 Mar 2016 00:43:02 GMT
 ```
-
- 
-
- 
-
-
-
-

--- a/develop/delete-a-device-for-the-specified-customer.md
+++ b/develop/delete-a-device-for-the-specified-customer.md
@@ -99,7 +99,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 204 No Content
 Content-Length: 0
 MS-CorrelationId: 394d96d0-05b2-4b02-b907-0697632ee3bb
@@ -107,13 +107,4 @@ MS-RequestId: 8b3e6f78-220b-4177-861b-33d6f38f7b97
 MS-CV: YrLe3w6BbUSMt1fi.0
 MS-ServerId: 030020344
 Date: Tue, 25 Jul 2017 17:58:53 GMT
-                    
 ```
-
- 
-
- 
-
-
-
-

--- a/develop/delete-user-accounts-for-a-customer.md
+++ b/develop/delete-user-accounts-for-a-customer.md
@@ -100,7 +100,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 204 No Content
 Content-Length: 0
 MS-CorrelationId: 709c0b80-016c-4662-b29f-697fdf03e87a
@@ -109,11 +109,3 @@ MS-CV: 90KUJA7HKEaG8wHu.0
 MS-ServerId: 101112616
 Date: Tue, 24 Jan 2017 23:27:18 GMT
 ```
-
- 
-
- 
-
-
-
-

--- a/develop/get-a-collection-of-entitlements.md
+++ b/develop/get-a-collection-of-entitlements.md
@@ -91,7 +91,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 103778
 Content-Type: application/json; charset=utf-8
@@ -208,7 +208,7 @@ Host: api.partnercenter.microsoft.com
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 368
 Content-Type: application/json; charset=utf-8
@@ -261,7 +261,7 @@ Host: api.partnercenter.microsoft.com
 
 **Response example**  
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 368
 Content-Type: application/json; charset=utf-8

--- a/develop/get-a-collection-of-invoices.md
+++ b/develop/get-a-collection-of-invoices.md
@@ -131,7 +131,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 256
 Content-Type: application/json; charset=utf-8

--- a/develop/get-a-customer-by-id.md
+++ b/develop/get-a-customer-by-id.md
@@ -92,7 +92,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 1530
 Content-Type: application/json; charset=utf-8

--- a/develop/get-a-customer-by-name.md
+++ b/develop/get-a-customer-by-name.md
@@ -132,7 +132,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 1839
 Content-Type: application/json; charset=utf-8

--- a/develop/get-a-customer-s-company-profile.md
+++ b/develop/get-a-customer-s-company-profile.md
@@ -95,7 +95,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 488
 Content-Type: application/json; charset=utf-8

--- a/develop/get-a-customer-s-service-costs-line-items.md
+++ b/develop/get-a-customer-s-service-costs-line-items.md
@@ -91,7 +91,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 2148
 Content-Type: application/json; charset=utf-8

--- a/develop/get-a-customer-s-service-costs-summary.md
+++ b/develop/get-a-customer-s-service-costs-summary.md
@@ -91,7 +91,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 766
 Content-Type: application/json; charset=utf-8

--- a/develop/get-a-customer-s-utilization-record-for-azure.md
+++ b/develop/get-a-customer-s-utilization-record-for-azure.md
@@ -184,7 +184,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 2630
 Content-Type: application/json; charset=utf-8

--- a/develop/get-a-customers-rated-usage-information.md
+++ b/develop/get-a-customers-rated-usage-information.md
@@ -92,7 +92,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 1120
 Content-Type: application/json

--- a/develop/get-a-list-of-a-customer-s-policies.md
+++ b/develop/get-a-list-of-a-customer-s-policies.md
@@ -93,7 +93,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 1221
 Content-Type: application/json; charset=utf-8

--- a/develop/get-a-list-of-add-ons-for-a-subscription.md
+++ b/develop/get-a-list-of-add-ons-for-a-subscription.md
@@ -97,7 +97,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 73754
 Content-Type: application/json

--- a/develop/get-a-list-of-all-user-accounts-for-a-customer.md
+++ b/develop/get-a-list-of-all-user-accounts-for-a-customer.md
@@ -92,7 +92,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 1030
 Content-Type: application/json; charset=utf-8

--- a/develop/get-a-list-of-availabilities-for-a-sku.md
+++ b/develop/get-a-list-of-availabilities-for-a-sku.md
@@ -108,7 +108,7 @@ This method returns the following error codes:
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Server: Microsoft-IIS/10.0

--- a/develop/get-a-list-of-available-licenses-by-license-group.md
+++ b/develop/get-a-list-of-available-licenses-by-license-group.md
@@ -103,7 +103,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 4328
 Content-Type: application/json; charset=utf-8

--- a/develop/get-a-list-of-available-licenses.md
+++ b/develop/get-a-list-of-available-licenses.md
@@ -91,7 +91,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 4859
 Content-Type: application/json; charset=utf-8

--- a/develop/get-a-list-of-customers.md
+++ b/develop/get-a-list-of-customers.md
@@ -97,7 +97,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 15650
 Content-Type: application/json

--- a/develop/get-a-list-of-devices-for-the-specified-batch-and-customer.md
+++ b/develop/get-a-list-of-devices-for-the-specified-batch-and-customer.md
@@ -93,7 +93,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 1742
 Content-Type: application/json; charset=utf-8

--- a/develop/get-a-list-of-offer-categories-by-country-and-locale.md
+++ b/develop/get-a-list-of-offer-categories-by-country-and-locale.md
@@ -93,7 +93,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 1184
 Content-Type: application/json

--- a/develop/get-a-list-of-offers-for-a-market.md
+++ b/develop/get-a-list-of-offers-for-a-market.md
@@ -92,7 +92,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 26584
 Content-Type: application/json

--- a/develop/get-a-list-of-orders-by-customer-and-billing-cycle-type.md
+++ b/develop/get-a-list-of-orders-by-customer-and-billing-cycle-type.md
@@ -74,7 +74,7 @@ None.
 
 **Request example**
 
-```
+```http
 GET https://api.partnercenter.microsoft.com/v1/customers/b0d70a69-4c42-4b27-b17b-91a835d8686a/orders?billingType=onetime HTTP/1.1
 Authorization: Bearer <token>
 Accept: application/json
@@ -94,7 +94,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 22463
 Content-Type: application/json; charset=utf-8

--- a/develop/get-a-list-of-products.md
+++ b/develop/get-a-list-of-products.md
@@ -99,7 +99,7 @@ This method returns the following error codes:
 
 **Response example**
 
-``` json
+```http
 {
     "totalCount": 19,
     "items": [

--- a/develop/get-a-list-of-skus-for-a-product.md
+++ b/develop/get-a-list-of-skus-for-a-product.md
@@ -106,7 +106,7 @@ This method returns the following error codes:
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Server: Microsoft-IIS/10.0

--- a/develop/get-a-list-of-subscriptions-by-order.md
+++ b/develop/get-a-list-of-subscriptions-by-order.md
@@ -96,7 +96,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 73754
 Content-Type: application/json

--- a/develop/get-a-list-of-trial-conversion-offers.md
+++ b/develop/get-a-list-of-trial-conversion-offers.md
@@ -94,7 +94,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 305
 Content-Type: application/json; charset=utf-8

--- a/develop/get-a-product-by-id.md
+++ b/develop/get-a-product-by-id.md
@@ -93,7 +93,7 @@ This method returns the following error codes:
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 1918
 Content-Type: application/json

--- a/develop/get-a-record-of-partner-center-activity-by-user.md
+++ b/develop/get-a-record-of-partner-center-activity-by-user.md
@@ -188,7 +188,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 2859
 Content-Type: application/json; charset=utf-8

--- a/develop/get-a-sku-by-id.md
+++ b/develop/get-a-sku-by-id.md
@@ -106,7 +106,7 @@ This method returns the following error codes:
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Server: Microsoft-IIS/10.0

--- a/develop/get-a-subscription-s-support-contact.md
+++ b/develop/get-a-subscription-s-support-contact.md
@@ -97,7 +97,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 328
 Content-Type: application/json; charset=utf-8

--- a/develop/get-a-subscriptions-resource-usage-information.md
+++ b/develop/get-a-subscriptions-resource-usage-information.md
@@ -94,7 +94,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 12014
 Content-Type: application/json

--- a/develop/get-a-user-account-by-id.md
+++ b/develop/get-a-user-account-by-id.md
@@ -91,7 +91,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 432
 Content-Type: application/json; charset=utf-8

--- a/develop/get-addon-offers-by-offer-id.md
+++ b/develop/get-addon-offers-by-offer-id.md
@@ -96,7 +96,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 3137
 Content-Type: application/json; charset=utf-8

--- a/develop/get-agreement-metadata.md
+++ b/develop/get-agreement-metadata.md
@@ -88,7 +88,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 620
 Content-Type: application/json

--- a/develop/get-all-azure-usage-analytics.md
+++ b/develop/get-all-azure-usage-analytics.md
@@ -216,7 +216,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 {
   "customerTenantId": "39A1DFAC-4969-4F31-AF94-D76588189CFE",
   "customerName": "A",

--- a/develop/get-all-indirect-resellers-analytics.md
+++ b/develop/get-all-indirect-resellers-analytics.md
@@ -260,7 +260,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 { 
     "partnerTenantId": "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE", 
     "id": "1111111", 

--- a/develop/get-all-of-a-customer-s-billing-profiles.md
+++ b/develop/get-all-of-a-customer-s-billing-profiles.md
@@ -94,7 +94,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 1206
 Content-Type: application/json

--- a/develop/get-all-of-a-customer-s-orders.md
+++ b/develop/get-all-of-a-customer-s-orders.md
@@ -93,7 +93,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 22463
 Content-Type: application/json; charset=utf-8

--- a/develop/get-all-of-a-customer-s-subscriptions.md
+++ b/develop/get-all-of-a-customer-s-subscriptions.md
@@ -93,7 +93,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 73754
 Content-Type: application/json

--- a/develop/get-all-referrals-analytics.md
+++ b/develop/get-all-referrals-analytics.md
@@ -78,7 +78,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 {
   "id": "112310",
   "status": "Accepted",

--- a/develop/get-all-search-analytics.md
+++ b/develop/get-all-search-analytics.md
@@ -80,7 +80,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 {
   "companyName": "my company",
   "contactButtonClicked": false,

--- a/develop/get-all-service-requests-for-a-customer.md
+++ b/develop/get-all-service-requests-for-a-customer.md
@@ -93,7 +93,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 742
 Content-Type: application/json

--- a/develop/get-all-subscription-analytics.md
+++ b/develop/get-all-subscription-analytics.md
@@ -81,7 +81,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 {
     "customerTenantId": "76906668-27FC-4F5B-A35C-75A9823E13AF",
     "customerName": "TESTORG65656565",

--- a/develop/get-all-subscriptions-by-partner.md
+++ b/develop/get-all-subscriptions-by-partner.md
@@ -98,7 +98,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 985
 Content-Type: application/json; charset=utf-8

--- a/develop/get-an-availability-by-id.md
+++ b/develop/get-an-availability-by-id.md
@@ -109,7 +109,7 @@ This method returns the following error codes:
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Server: Microsoft-IIS/10.0

--- a/develop/get-an-offer-by-id.md
+++ b/develop/get-an-offer-by-id.md
@@ -96,7 +96,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 1918
 Content-Type: application/json

--- a/develop/get-an-order-by-id.md
+++ b/develop/get-an-order-by-id.md
@@ -96,7 +96,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 823
 Content-Type: application/json

--- a/develop/get-an-organization-profile.md
+++ b/develop/get-an-organization-profile.md
@@ -80,7 +80,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 648
 Content-Type: application/json; charset=utf-8

--- a/develop/get-confirmation-of-customer-consent.md
+++ b/develop/get-confirmation-of-customer-consent.md
@@ -101,7 +101,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 620
 Content-Type: application/json

--- a/develop/get-customer-licenses-deployment-information.md
+++ b/develop/get-customer-licenses-deployment-information.md
@@ -88,7 +88,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 1012
 Content-Type: application/json; charset=utf-8

--- a/develop/get-customer-licenses-usage-information.md
+++ b/develop/get-customer-licenses-usage-information.md
@@ -89,7 +89,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 1726
 Content-Type: application/json; charset=utf-8

--- a/develop/get-customers-of-an-indirect-reseller.md
+++ b/develop/get-customers-of-an-indirect-reseller.md
@@ -136,7 +136,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 2273
 Content-Type: application/json; charset=utf-8

--- a/develop/get-indirect-resellers-of-a-customer.md
+++ b/develop/get-indirect-resellers-of-a-customer.md
@@ -12,7 +12,6 @@ ms.localizationpriority: medium
 
 # Get indirect resellers of a customer
 
-
 **Applies To**
 
 -   Partner Center
@@ -70,7 +69,7 @@ None.
 
 **Request example**
 
-```
+```http
 GET https://api.partnercenter.microsoft.com/v1/customers/c501c3c4-d776-40ef-9ecf-9cefb59442c1/relationships HTTP/1.1
 Authorization: Bearer <token>
 Accept: application/json
@@ -82,7 +81,6 @@ Host: api.partnercenter.microsoft.com
 
 ## <span id="Response"></span><span id="response"></span><span id="RESPONSE"></span>Response
 
-
 If successful, the response body contains a collection of [PartnerRelationship](relationships.md) resources to identify the resellers.
 
 **Response success and error codes**
@@ -91,7 +89,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 264
 Content-Type: application/json; charset=utf-8
@@ -118,11 +116,3 @@ Date: Fri, 07 Apr 2017 23:42:11 GMT
     }
 }
 ```
-
- 
-
- 
-
-
-
-

--- a/develop/get-invoice-by-id.md
+++ b/develop/get-invoice-by-id.md
@@ -12,7 +12,6 @@ ms.localizationpriority: medium
 
 # Get invoice by ID
 
-
 **Applies To**
 
 -   Partner Center
@@ -44,7 +43,6 @@ var invoice = scopedPartnerOperations.Invoices.ById(selectedInvoiceId).Get();
 
 ## <span id="Request"></span><span id="request"></span><span id="REQUEST"></span>REST Request
 
-
 **Request syntax**
 
 | Method  | Request URI                                                                   |
@@ -73,7 +71,7 @@ None
 
 **Request example**
 
-```
+```http
 GET https://api.partnercenter.microsoft.com/v1/invoices/<invoice-id> HTTP/1.1
 Authorization: Bearer <token>
 Accept: application/json
@@ -92,7 +90,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 676
 Content-Type: application/json; charset=utf-8
@@ -138,11 +136,3 @@ Date: Thu, 24 Mar 2016 05:22:14 GMT
     }
 }
 ```
-
- 
-
- 
-
-
-
-

--- a/develop/get-invoice-statement.md
+++ b/develop/get-invoice-statement.md
@@ -12,7 +12,6 @@ ms.localizationpriority: medium
 
 # Get invoice statement
 
-
 **Applies To**
 
 -   Partner Center
@@ -51,7 +50,6 @@ var invoiceStatement = scopedPartnerOperations.Invoices.ById(selectedInvoiceId).
 |---------|---------------------------------------------------------------------------------------------------|
 | **GET** | [*{baseURL}*](partner-center-rest-urls.md)/v1/invoices/{invoice-id}/documents/statement HTTP/1.1  |
 
- 
 
 **URI parameter**
 
@@ -73,7 +71,7 @@ None
 
 **Request example**
 
-```
+```http
 GET https://api.partnercenter.microsoft.com/v1/invoices/<invoice-id>/documents/statement HTTP/1.1
 Authorization: Bearer <token>
 Accept: application/json
@@ -92,7 +90,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 219753
 Content-Type: application/json; charset=utf-8
@@ -106,11 +104,3 @@ Date: Thu, 24 Mar 2016 05:21:01 GMT
     _headers	{Content-Type: application/pdf Content-Disposition: attachment; filename=Invoice_G000024132.pdf}
 }
 ```
-
- 
-
- 
-
-
-
-

--- a/develop/get-invoice-summaries.md
+++ b/develop/get-invoice-summaries.md
@@ -12,7 +12,6 @@ ms.localizationpriority: medium
 
 # Get invoice summaries
 
-
 **Applies To**
 
 -   Partner Center
@@ -54,7 +53,6 @@ Console.Out.WriteLine("Current Account Balance:  {0:C}", invoiceSummaries[0].Bal
 |---------|-------------------------------------------------------------------------------|
 | **GET** | [*{baseURL}*](partner-center-rest-urls.md)/v1/invoices/summaries HTTP/1.1     |
 
- 
 
 **URI parameter**
 
@@ -71,7 +69,7 @@ None.
 
 **Request example**
 
-```
+```http
 GET https://api.partnercenter.microsoft.com/v1/invoices/summaries HTTP/1.1
 Authorization: Bearer <token>
 Accept: application/json
@@ -82,7 +80,6 @@ Connection: Keep-Alive
 
 ## <span id="Response"></span><span id="response"></span><span id="RESPONSE"></span>REST Response
 
-
 If successful, this method returns an [InvoiceSummaries](invoice.md#invoicesummaries) resource in the response body.
 
 **Response success and error codes**
@@ -91,7 +88,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 256
 Content-Type: application/json; charset=utf-8
@@ -245,11 +242,3 @@ Date: Thu, 24 Mar 2016 05:21:01 GMT
     }
 }
 ```
-
- 
-
- 
-
-
-
-

--- a/develop/get-legal-business-profile.md
+++ b/develop/get-legal-business-profile.md
@@ -12,7 +12,6 @@ ms.localizationpriority: medium
 
 # Get the partner legal business profile
 
-
 **Applies To**
 
 -   Partner Center
@@ -24,11 +23,9 @@ How to get a partner's legal business profile.
 
 ## <span id="Prerequisites"></span><span id="prerequisites"></span><span id="PREREQUISITES"></span>Prerequisites
 
-
 -   Credentials as described in [Partner Center authentication](partner-center-authentication.md). This scenario supports authentication with both standalone App and App+User credentials.
 
 ## <span id="C_"></span><span id="c_"></span>C#
-
 
 To get the partner legal business profile, first get an interface to the collection of partner profile operations from the **IAggregatePartner.Profiles** property. Then, get the value of the **LegalBusinessProfile** property to retrieve an interface to legal business profile operations. Finally, call the [**Get**](https://docs.microsoft.com/dotnet/api/microsoft.store.partnercenter.profiles.ilegalbusinessprofile.get) or the [**GetAsync**](https://docs.microsoft.com/dotnet/api/microsoft.store.partnercenter.profiles.ilegalbusinessprofile.getasync) method to retrieve the profile.
 
@@ -61,7 +58,7 @@ None.
 
 **Request example**
 
-```
+```http
 GET https://api.partnercenter.microsoft.com/v1/profiles/legalbusiness?vettingVersion=Current HTTP/1.1
 Authorization: Bearer <token>
 Accept: application/json
@@ -74,7 +71,6 @@ Connection: Keep-Alive
 
 ## <span id="Response"></span><span id="response"></span><span id="RESPONSE"></span>Response
 
-
 If successful, this method returns a **LegalBusinessProfile** object in the response body.
 
 **Response success and error codes**
@@ -83,7 +79,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 1151
 Content-Type: application/json; charset=utf-8
@@ -136,11 +132,3 @@ Date: Tue, 21 Mar 2017 17:29:52 GMT
     }
 }
 ```
-
- 
-
- 
-
-
-
-

--- a/develop/get-licenses-assigned-to-a-user-by-license-group.md
+++ b/develop/get-licenses-assigned-to-a-user-by-license-group.md
@@ -12,7 +12,6 @@ ms.localizationpriority: medium
 
 # Get licenses assigned to a user by license group
 
-
 **Applies To**
 
 -   Partner Center
@@ -52,7 +51,6 @@ var customerUserBothAadAndSfbAssignedLicenses = partnerOperations.Customers.ById
 
 ## <span id="_Request"></span><span id="_request"></span><span id="_REQUEST"></span> Request
 
-
 **Request syntax**
 
 | Method  | Request URI                                                                                                                                            |
@@ -61,7 +59,6 @@ var customerUserBothAadAndSfbAssignedLicenses = partnerOperations.Customers.ById
 | **GET** | [*{baseURL}*](partner-center-rest-urls.md)/v1/customers/{customer-id}/users/{user-id}/licenses?licenseGroupIds=Group2 HTTP/1.1                        |
 | **GET** | [*{baseURL}*](partner-center-rest-urls.md)/v1/customers/{customer-id}/users/{user-id}/licenses?licenseGroupIds=Group1&licenseGroupIds=Group2 HTTP/1.1 |
 
- 
 
 **URI parameter**
 
@@ -85,7 +82,7 @@ None.
 
 **Request example**
 
-```
+```http
 GET https://api.partnercenter.microsoft.com/v1/customers/0c39d6d5-c70d-4c55-bc02-f620844f3fd1/users/482e2152-4b49-48ec-b715-823365ce3d4c/licenses?licenseGroupIds=Group1&amp;licenseGroupIds=Group2 HTTP/1.1
 Authorization: Bearer <token>
 Accept: application/json
@@ -97,7 +94,6 @@ Host: api.partnercenter.microsoft.com
 
 ## <span id="_Response"></span><span id="_response"></span><span id="_RESPONSE"></span> Response
 
-
 If successful, the response body contains the collection of [License](licenses.md#license) resources.
 
 **Response success and error codes**
@@ -106,7 +102,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Type: application/json
 MS-CorrelationId: 8a53b025-d5be-4d98-ab20-229d1813de76
@@ -164,7 +160,7 @@ Date: June 24 2016 22:00:25 PST
 
 If no matching licenses can be found for the specified license groups, the response contains an empty collection with a totalCount element whose value is 0.
 
-```
+```http
 HTTP/1.1 200 OK
 Content-Length: 71
 Content-Type: application/json; charset=utf-8
@@ -182,11 +178,3 @@ Date: Fri, 09 Jun 2017 22:50:11 GMT
     }
 }
 ```
-
- 
-
- 
-
-
-
-

--- a/develop/get-market-specific-validation-data.md
+++ b/develop/get-market-specific-validation-data.md
@@ -12,7 +12,6 @@ ms.localizationpriority: medium
 
 # Get address formatting rules by market
 
-
 **Applies To**
 
 -   Partner Center
@@ -56,13 +55,12 @@ None.
 
 **Request example**
 
-```
+```http
 GET https://api.partnercenter.microsoft.com/v1/countryvalidationrules/{isocode-id} HTTP/1.1
 Authorization: Bearer <token> 
 Accept: application/json
 MS-RequestId: 124b0e41-a093-4fec-b871-3eeb45fd734b
 MS-CorrelationId: 5cfd634d-b936-47af-87f0-0f0217425dcc
-
 ```
 
 ## <span id="Response"></span><span id="response"></span><span id="RESPONSE"></span>Response
@@ -76,7 +74,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 1856
 Content-Type: application/json
@@ -123,13 +121,4 @@ Date: Wed, 25 Nov 2015 06:36:47 GMT
         "objectType": "CountryInformation"
     }
 }
-
 ```
-
- 
-
- 
-
-
-
-

--- a/develop/get-partner-billing-profile.md
+++ b/develop/get-partner-billing-profile.md
@@ -12,7 +12,6 @@ ms.localizationpriority: medium
 
 # Get partner billing profile
 
-
 **Applies To**
 
 -   Partner Center
@@ -61,7 +60,7 @@ None.
 
 **Request example**
 
-```
+```http
 GET https://api.partnercenter.microsoft.com/v1/profiles/billing HTTP/1.1
 Authorization: Bearer <token>
 Accept: application/json
@@ -80,7 +79,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 568
 Content-Type: application/json; charset=utf-8
@@ -119,11 +118,3 @@ Date: Tue, 22 Mar 2016 17:10:02 GMT
     }
 }
 ```
-
- 
-
- 
-
-
-
-

--- a/develop/get-partner-licenses-deployment-information.md
+++ b/develop/get-partner-licenses-deployment-information.md
@@ -12,7 +12,6 @@ ms.localizationpriority: medium
 
 # Get partner licenses deployment information
 
-
 **Applies To**
 
 -   Partner Center
@@ -56,7 +55,7 @@ None.
 
 **Request example**
 
-```
+```http
 GET https://api.partnercenter.microsoft.com/v1/analytics/licenses/deployment HTTP/1.1
 Authorization: Bearer <token>
 Accept: application/json
@@ -68,7 +67,6 @@ Host: api.partnercenter.microsoft.com
 
 ## <span id="Response"></span><span id="response"></span><span id="RESPONSE"></span>Response
 
-
 If successful, the response body contains a collection of [PartnerLicensesDeploymentInsights](analytics.md#partnerlicensesdeploymentinsights) resources that provide information about the licenses deployed.
 
 **Response success and error codes**
@@ -77,7 +75,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 487
 Content-Type: application/json; charset=utf-8
@@ -114,11 +112,3 @@ Date: Tue, 14 Mar 2017 17:55:01 GMT
     }
 }
 ```
-
- 
-
- 
-
-
-
-

--- a/develop/get-partner-licenses-usage-information.md
+++ b/develop/get-partner-licenses-usage-information.md
@@ -12,7 +12,6 @@ ms.localizationpriority: medium
 
 # Get partner licenses usage information
 
-
 **Applies To**
 
 -   Partner Center
@@ -56,7 +55,7 @@ None.
 
 **Request example**
 
-```
+```http
 GET https://api.partnercenter.microsoft.com/v1/analytics/licenses/usage HTTP/1.1
 Authorization: Bearer <token>
 Accept: application/json
@@ -68,7 +67,6 @@ Host: api.partnercenter.microsoft.com
 
 ## <span id="Response"></span><span id="response"></span><span id="RESPONSE"></span>Response
 
-
 If successful, the response body contains a collection of [PartnerLicensesUsageInsights](analytics.md#partnerlicensesusageinsights) resources that provide information about the licenses used.
 
 **Response success and error codes**
@@ -77,7 +75,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 1156
 Content-Type: application/json; charset=utf-8
@@ -141,11 +139,3 @@ Date: Wed, 15 Mar 2017 01:18:26 GMT
     }
 }
 ```
-
- 
-
- 
-
-
-
-

--- a/develop/get-partner-network-profile.md
+++ b/develop/get-partner-network-profile.md
@@ -61,7 +61,7 @@ None.
 
 **Request example**
 
-```
+```http
 GET https://api.partnercenter.microsoft.com/v1/profiles/mpn HTTP/1.1
 Authorization: Bearer <token>
 Accept: application/json
@@ -81,7 +81,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 177
 Content-Type: application/json; charset=utf-8
@@ -105,11 +105,3 @@ Date: Mon, 21 Mar 2016 05:51:29 GMT
 }
 
 ```
-
- 
-
- 
-
-
-
-

--- a/develop/get-prices-for-microsoft-azure-partner-shared-services.md
+++ b/develop/get-prices-for-microsoft-azure-partner-shared-services.md
@@ -55,7 +55,7 @@ None.
 
 **Request example**
 
-```
+```http
 GET https://api.partnercenter.microsoft.com/v1/ratecards/azure-shared HTTP/1.1
 Authorization: Bearer <token>
 Accept: application/json
@@ -77,7 +77,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 1545508
 Content-Type: application/json; charset=utf-8
@@ -144,11 +144,3 @@ Date: Wed, 01 Feb 2017 00:13:45 GMT
     }
 }
 ```
-
- 
-
- 
-
-
-
-

--- a/develop/get-prices-for-microsoft-azure.md
+++ b/develop/get-prices-for-microsoft-azure.md
@@ -69,7 +69,7 @@ None.
 
 **Request example**
 
-```
+```http
 GET https://api.partnercenter.microsoft.com/v1/ratecards/azure HTTP/1.1
 Authorization: Bearer <token>
 Accept: application/json
@@ -91,7 +91,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 1545508
 Content-Type: application/json; charset=utf-8
@@ -158,11 +158,3 @@ Date: Wed, 01 Feb 2017 00:13:45 GMT
     }
 }
 ```
-
- 
-
- 
-
-
-
-

--- a/develop/get-service-request-details-by-id.md
+++ b/develop/get-service-request-details-by-id.md
@@ -76,7 +76,7 @@ None.
 
 **Request example**
 
-```
+```http
 GET https://api.partnercenter.microsoft.com/v1/servicerequests/616122292874576 HTTP/1.1
 Authorization: Bearer <token>
 Accept: application/json
@@ -99,7 +99,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 566
 Content-Type: application/json; charset=utf-8
@@ -136,4 +136,3 @@ Date: Mon, 09 Jan 2017 23:31:15 GMT
     }
 }
 ```
-

--- a/develop/get-service-request-support-topics--pending-.md
+++ b/develop/get-service-request-support-topics--pending-.md
@@ -58,7 +58,7 @@ None.
 
 **Request example**
 
-```
+```http
 GET https://api.partnercenter.microsoft.com/v1/servicerequests/supporttopics HTTP/1.1
 Authorization: Bearer <token>
 Accept: application/json
@@ -78,7 +78,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 4982
 Content-Type: application/json
@@ -109,11 +109,3 @@ Date: Fri, 29 Jan 2016 22:31:36 GMT
     }
 }
 ```
-
- 
-
- 
-
-
-
-

--- a/develop/get-subscription-analytics-by-search-query.md
+++ b/develop/get-subscription-analytics-by-search-query.md
@@ -107,7 +107,7 @@ None.
 
 **Request example**
 
-```
+```http
 GET https://api.partnercenter.microsoft.com/partner/v1/analytics/subscriptions?filter=autoRenewEnabled eq true
 Authorization: Bearer <token>
 Accept: application/json
@@ -128,7 +128,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 177
 Content-Type: application/json; charset=utf-8
@@ -160,6 +160,6 @@ MS-RequestId: ec8f62e5-1d92-47e9-8d5d-1924af105123
 }
 ```
 
-
 ## <span id="See_Also"></span><span id="see_also"></span><span id="SEE_ALSO"></span>See also
+
  - [Partner Center Analytics - Resources](partner-center-analytics-resources.md)

--- a/develop/get-subscription-analytics-grouped-by-dates-or-terms.md
+++ b/develop/get-subscription-analytics-grouped-by-dates-or-terms.md
@@ -108,7 +108,7 @@ None.
 
 **Request example**
 
-```
+```http
 GET https://api.partnercenter.microsoft.com/partner/v1/analytics/subscriptions?groupBy=subscriptionType  
 Authorization: Bearer <token>
 Accept: application/json
@@ -120,7 +120,6 @@ Content-Length: 0
 
 ## <span id="Response"></span><span id="response"></span><span id="RESPONSE"></span>REST Response
 
-
 If successful, the response body contains a collection of [Subscription](partner-center-analytics-resources.md#subscription) resources grouped by the specified terms and dates.
 
 **Response success and error codes**
@@ -129,7 +128,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 177
 Content-Type: application/json; charset=utf-8
@@ -178,6 +177,6 @@ MS-RequestId: ec8f62e5-1d92-47e9-8d5d-1924af105123
 }
 ```
 
-
 ## <span id="See_Also"></span><span id="see_also"></span><span id="SEE_ALSO"></span>See also
+
  - [Partner Center Analytics - Resources](partner-center-analytics-resources.md)

--- a/develop/get-subscription-provisioning-status.md
+++ b/develop/get-subscription-provisioning-status.md
@@ -12,7 +12,6 @@ ms.localizationpriority: medium
 
 # Get subscription provisioning status
 
-
 **Applies To**
 
 -   Partner Center
@@ -76,7 +75,7 @@ None.
 
 **Request example**
 
-```
+```http
 GET https://api.partnercenter.microsoft.com/v1/customers/0c39d6d5-c70d-4c55-bc02-f620844f3fd1/subscriptions/34828C05-C16C-4D6F-9CFC-4D2650EF19A1/provisioningstatus HTTP/1.1
 Accept: application/json, text/plain, */*
 Authorization: Bearer <token>
@@ -97,7 +96,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 177
 Content-Type: application/json; charset=utf-8
@@ -120,14 +119,5 @@ Date: Thu, 20 Apr 2017 19:23:39 GMT
 
 ## <span id="Remarks"></span><span id="remarks"></span><span id="REMARKS"></span>Remarks
 
-
 -   During a seat change assignment, the status field in [SubscriptionProvisioningStatus](subscriptions.md#subscriptionprovisioningstatus) is set to "pending".
 -   The status field is updated every fifteen minutes.
-
- 
-
- 
-
-
-
-

--- a/develop/get-subscription-registration-status.md
+++ b/develop/get-subscription-registration-status.md
@@ -12,7 +12,6 @@ ms.localizationpriority: medium
 
 # Get subscription registration status 
 
-
 **Applies To**
 
 -   Partner Center
@@ -42,17 +41,13 @@ To get the registration status of a subscription, begin by using the [**IAggrega
 var subscriptionRegistrationDetails = partnerOperations.Customers.ById(selectedCustomerId).Subscriptions.ById(selectedSubscriptionId).RegistrationStatus.Get();
 ```
 
-
 ## <span id="REST_Request"></span><span id="rest_request"></span><span id="REST_REQUEST"></span>REST Request
-
 
 **Request syntax**
 
 | Method    | Request URI                                                                                                                        |
 |-----------|------------------------------------------------------------------------------------------------------------------------------------|
 | **GET**  | [*{baseURL}*](partner-center-rest-urls.md)/v1/customers/{customer-id}/subscriptions/{subscription-id}/registrationstatus HTTP/1.1 |
-
- 
 
 **URI parameters**
 
@@ -64,7 +59,6 @@ Use the following path parameters to identify the customer and subscription.
 | subscription-id         | string     | Yes      | A GUID formatted string that identifies the subscription.     |
 
  
-
 **Request headers**
 
 -   See [Headers](headers.md) for more information.
@@ -75,7 +69,7 @@ None.
 
 **Request example**
 
-```
+```http
 GET https://api.partnercenter.microsoft.com/v1/customers/<customer-id>/subscriptions/<subscription-id>/registrationstatus HTTP/1.1
 Authorization: Bearer <token>
 Accept: application/json
@@ -89,7 +83,6 @@ Connection: Keep-Alive
 
 ## <span id="REST_Response"></span><span id="rest_response"></span><span id="REST_RESPONSE"></span>REST Response
 
-
 If successful, the response body contains a [SubscriptionRegistrationStatus](subscriptions.md#subscriptionregistrationstatus) resource.  
 
 **Response success and error codes**
@@ -98,7 +91,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 177
 Content-Type: application/json; charset=utf-8
@@ -115,11 +108,3 @@ MS-ServerId: 030020344
     }
 }
 ```
-
- 
-
- 
-
-
-
-

--- a/develop/get-support-profile.md
+++ b/develop/get-support-profile.md
@@ -23,11 +23,9 @@ Gets an object representing a user's support profile.
 
 ## <span id="Prerequisites"></span><span id="prerequisites"></span><span id="PREREQUISITES"></span>Prerequisites
 
-
 -   Credentials as described in [Partner Center authentication](partner-center-authentication.md). This scenario supports authentication with App+User credentials only.
 
 ## <span id="C_"></span><span id="c_"></span>C#
-
 
 To get your support profile, use your **IAggregatePartner.Profiles** collection. Call the [**SupportProfile**](https://docs.microsoft.com/dotnet/api/microsoft.store.partnercenter.profiles.isupportprofile) property, followed by the [**Get()**](https://docs.microsoft.com/dotnet/api/microsoft.store.partnercenter.profiles.isupportprofile.get) or [**GetAsync()**](https://docs.microsoft.com/dotnet/api/microsoft.store.partnercenter.profiles.isupportprofile.getasync) methods.
 
@@ -41,14 +39,11 @@ SupportProfile supportProfile = partnerOperations.Profiles.SupportProfile.Get();
 
 ## <span id="Request"></span><span id="request"></span><span id="REQUEST"></span>Request
 
-
 **Request syntax**
 
 | Method  | Request URI                                                              |
 |---------|--------------------------------------------------------------------------|
 | **GET** | [*{baseURL}*](partner-center-rest-urls.md)/v1/profiles/support HTTP/1.1 |
-
- 
 
 **Request headers**
 
@@ -60,7 +55,7 @@ None.
 
 **Request example**
 
-```
+```http
 GET https://api.partnercenter.microsoft.com/v1/profiles/support HTTP/1.1
 Authorization: Bearer <token>
 Accept: application/json
@@ -71,7 +66,6 @@ MS-CorrelationId: 20604323-50bf-4738-9968-c5486ab32be0
 
 ## <span id="Response"></span><span id="response"></span><span id="RESPONSE"></span>Response
 
-
 If successful, this method returns a **SupportProfile** object in the response body.
 
 **Response success and error codes**
@@ -80,7 +74,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 502
 Content-Type: application/json
@@ -106,11 +100,3 @@ Date: Wed, 25 Nov 2015 07:16:17 GMT
 }
 
 ```
-
- 
-
- 
-
-
-
-

--- a/develop/get-the-list-of-device-batches-for-the-specified-customer.md
+++ b/develop/get-the-list-of-device-batches-for-the-specified-customer.md
@@ -34,8 +34,8 @@ Each device batch contains summary status information about devices that have be
 To get the collection of device batches for the specified customer, first call the [**IAggregatePartner.Customers.ById**](https://docs.microsoft.com/dotnet/api/microsoft.store.partnercenter.customers.icustomercollection.byid) method with the customer ID to retrieve an interface to operations on the specified customer. Then, retrieve the value of the [**DeviceBatches**](https://docs.microsoft.com/dotnet/api/microsoft.store.partnercenter.customers.icustomer.devicebatches) property to get an interface to device batch collection operations. Finally, call the [**Get**](https://docs.microsoft.com/dotnet/api/microsoft.store.partnercenter.devicesdeployment.idevicesbatchcollection.get) or [**GetAsync**](https://docs.microsoft.com/dotnet/api/microsoft.store.partnercenter.devicesdeployment.idevicesbatchcollection.getasync) method to retrieve the collection.
 
 ``` csharp
-IAggregatePartner partnerOperations;
-string selectedCustomerId;
+// IAggregatePartner partnerOperations;
+// string selectedCustomerId;
 
 var devicesBatches = 
     partnerOperations.Customers.ById(selectedCustomerId).DeviceBatches.Get();
@@ -74,7 +74,7 @@ None
 
 **Request example**
 
-```
+```http
 GET https://api.partnercenter.microsoft.com/v1/customers/47021739-3426-40bf-9601-61b4b6d7c793/deviceBatches HTTP/1.1
 Authorization: Bearer <token> 
 Accept: application/json
@@ -86,7 +86,6 @@ Host: api.partnercenter.microsoft.com
 
 ## <span id="Response"></span><span id="response"></span><span id="RESPONSE"></span>Response
 
-
 If successful, the response body contains the collection of [DeviceBatch](devicedeployment.md#devicebatch) resources.
 
 **Response success and error codes**
@@ -95,7 +94,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 339
 Content-Type: application/json; charset=utf-8
@@ -127,11 +126,3 @@ Date: Tue, 25 Jul 2017 17:52:41 GMT
     }
 }
 ```
-
- 
-
- 
-
-
-
-

--- a/develop/get-the-managed-services-for-a-customer-by-id.md
+++ b/develop/get-the-managed-services-for-a-customer-by-id.md
@@ -72,7 +72,7 @@ None.
 
 **Request example**
 
-```
+```http
 GET https://api.partnercenter.microsoft.com/v1/customers/<customer-tenant-id>/managedservices HTTP/1.1
 Authorization: Bearer <token>
 Accept: application/json
@@ -82,7 +82,6 @@ MS-CorrelationId: 03d6064a-f048-4aee-8892-ed46dc5c8bee
 
 ## <span id="REST_Response"></span><span id="rest_response"></span><span id="REST_RESPONSE"></span>REST Response
 
-
 If successful, this method returns a collection of **Managed Service** objects in the response body.
 
 **Response success and error codes**
@@ -91,7 +90,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 10588
 Content-Type: application/json
@@ -152,11 +151,3 @@ Date: Mon, 23 Nov 2015 18:02:12 GMT
         }
     }
 ```
-
- 
-
- 
-
-
-
-

--- a/develop/get-the-reseller-s-current-account-balance.md
+++ b/develop/get-the-reseller-s-current-account-balance.md
@@ -83,7 +83,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 256
 Content-Type: application/json; charset=utf-8
@@ -146,11 +146,3 @@ Date: Thu, 24 Mar 2016 05:21:01 GMT
     }
 }
 ```
-
- 
-
- 
-
-
-
-

--- a/develop/get-the-status-of-a-device-batch-upload.md
+++ b/develop/get-the-status-of-a-device-batch-upload.md
@@ -33,9 +33,9 @@ How to get the status of a device batch upload for a specified customer.
 To get the status of a device batch upload, first call the [**IAggregatePartner.Customers.ById**](https://docs.microsoft.com/dotnet/api/microsoft.store.partnercenter.customers.icustomercollection.byid) method with the customer ID to retrieve an interface to operations on the specified customer. Then, call the [**BatchUploadStatus.ById**](https://docs.microsoft.com/dotnet/api/microsoft.store.partnercenter.devicesdeployment.ibatchjobstatuscollection.byid) method with the batch tracking ID to get an interface to batch upload status operations. Finally, call the [**Get**](https://docs.microsoft.com/dotnet/api/microsoft.store.partnercenter.devicesdeployment.ibatchjobstatus.get) or [**GetAsync**](https://docs.microsoft.com/dotnet/api/microsoft.store.partnercenter.devicesdeployment.ibatchjobstatus.getasync) method to retrieve the status.
 
 ``` csharp
-IAggregatePartner partnerOperations; 
-string selectedCustomerId; 
-string selectedTrackingId; 
+// IAggregatePartner partnerOperations;
+// string selectedCustomerId;
+// string selectedTrackingId;
 
 var status = 
     partnerOperations.Customers.ById(selectedCustomerId).BatchUploadStatus.ById(selectedTrackingId).Get();
@@ -75,7 +75,7 @@ None
 
 **Request example**
 
-```
+```http
 GET https://api.partnercenter.microsoft.com/v1/customers/47021739-3426-40bf-9601-61b4b6d7c793/batchjobstatus/0127ed8e-ff72-4983-a3d8-e8d8bd378932 HTTP/1.1
 Authorization: Bearer <token> 
 Accept: application/json
@@ -96,7 +96,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 400
 MS-CorrelationId: 4a5002a2-0c1b-4e57-b491-dbcf19c0e7b8
@@ -123,14 +123,6 @@ Date: Tue, 25 Jul 2017 17:52:41 GMT
     ],
     "attributes": {
         "objectType": "BatchUploadDetails"
-    }    
+    }
 }
 ```
-
- 
-
- 
-
-
-
-

--- a/develop/get-user-roles-for-a-customer.md
+++ b/develop/get-user-roles-for-a-customer.md
@@ -103,7 +103,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 31942
 Content-Type: application/json
@@ -128,11 +128,3 @@ Date: June 24 2016 22:00:25 PST
       "attributes": { "objectType": "Collection" }
 }
 ```
-
- 
-
- 
-
-
-
-

--- a/develop/partner-center-webhooks.md
+++ b/develop/partner-center-webhooks.md
@@ -152,7 +152,7 @@ host: api.partnercenter.microsoft.com
 
 **Response example**   
 
-``` json
+```http
 HTTP/1.1 200
 Status: 200
 Content-Length: 183
@@ -195,7 +195,7 @@ Content-Length: 219
 
 **Response example**   
 
-``` json
+```http
 HTTP/1.1 200
 Status: 200
 Content-Length: 346
@@ -235,7 +235,7 @@ Accept-Encoding: gzip, deflate
 
 **Response example**   
 
-``` json
+```http
 HTTP/1.1 200
 Status: 200
 Content-Length: 341
@@ -281,7 +281,7 @@ Content-Length: 258
 
 **Response example**   
 
-``` json
+```http
 HTTP/1.1 200
 Status: 200
 Content-Length: 346
@@ -324,7 +324,7 @@ Content-Length:
 
 **Response example**   
 
-``` json
+```http
 HTTP/1.1 200
 Status: 200
 Content-Length: 181
@@ -360,7 +360,7 @@ Accept-Encoding: gzip, deflate
 
 **Response example**     
 
-``` json
+```http
 HTTP/1.1 200
 Status: 200
 Content-Length: 469

--- a/develop/purchase-an-add-on-to-a-subscription.md
+++ b/develop/purchase-an-add-on-to-a-subscription.md
@@ -221,7 +221,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 1135
 Content-Type: application/json; charset=utf-8

--- a/develop/reactivate-a-suspended-a-subscription.md
+++ b/develop/reactivate-a-suspended-a-subscription.md
@@ -127,7 +127,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 PATCH https://api.partnercenter.microsoft.com/v1/customers/<customer-tenant-id>/subscriptions/<subscriptionID> HTTP/1.1
 Authorization: Bearer <token>
 Accept: application/json

--- a/develop/register-a-subscription.md
+++ b/develop/register-a-subscription.md
@@ -100,7 +100,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 202 Accepted
 Content-Length: 0
 Location: /customers/<customer-id>/subscriptions/<subscription-id>/registrationstatus

--- a/develop/remove-a-reseller-relationship-with-a-customer.md
+++ b/develop/remove-a-reseller-relationship-with-a-customer.md
@@ -143,7 +143,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 MS-RequestId: 7988dde4-b516-472c-b226-6d53fb18f04e
 MS-CorrelationId: 9b4bf2ca-f374-4d51-9113-781ca87b8380

--- a/develop/remove-customer-user-from-a-role.md
+++ b/develop/remove-customer-user-from-a-role.md
@@ -97,7 +97,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 204 No Content
 Content-Length: 0
 MS-CorrelationId: 90bda268-7929-4ad6-be01-89c5af5fc504

--- a/develop/request-reseller-relationship.md
+++ b/develop/request-reseller-relationship.md
@@ -82,7 +82,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 196
 Content-Type: application/json; charset=utf-8

--- a/develop/reset-user-password-for-a-customer.md
+++ b/develop/reset-user-password-for-a-customer.md
@@ -113,7 +113,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 31942
 Content-Type: application/json

--- a/develop/restore-a-user-for-a-customer.md
+++ b/develop/restore-a-user-for-a-customer.md
@@ -122,7 +122,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 465
 Content-Type: application/json; charset=utf-8

--- a/develop/retrieve-a-customer-s-configuration-policy.md
+++ b/develop/retrieve-a-customer-s-configuration-policy.md
@@ -97,7 +97,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 443
 MS-CorrelationId: abe150cf-c677-435c-b5d5-b34899a6d1ec

--- a/develop/retrieve-a-list-of-indirect-resellers.md
+++ b/develop/retrieve-a-list-of-indirect-resellers.md
@@ -112,7 +112,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 298
 Content-Type: application/json; charset=utf-8

--- a/develop/set-user-roles-for-a-customer.md
+++ b/develop/set-user-roles-for-a-customer.md
@@ -124,7 +124,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 201 Created
 Content-Length: 231
 Content-Type: application/json; charset=utf-8

--- a/develop/suspend-a-subscription.md
+++ b/develop/suspend-a-subscription.md
@@ -127,7 +127,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 PATCH https://api.partnercenter.microsoft.com/v1/customers/<customer-tenant-id>/subscriptions/<subscriptionID> HTTP/1.1
 Authorization: Bearer <token>
 Accept: application/json

--- a/develop/transition-a-subscription.md
+++ b/develop/transition-a-subscription.md
@@ -161,7 +161,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 138
 Content-Type: application/json

--- a/develop/update-a-cart.md
+++ b/develop/update-a-cart.md
@@ -156,7 +156,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 201 Created
 Content-Length: 764
 Content-Type: application/json; charset=utf-8

--- a/develop/update-a-configuration-policy-for-the-specified-customer.md
+++ b/develop/update-a-configuration-policy-for-the-specified-customer.md
@@ -127,7 +127,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 421
 Content-Type: application/json; charset=utf-8

--- a/develop/update-a-customer-s-billing-profile.md
+++ b/develop/update-a-customer-s-billing-profile.md
@@ -133,7 +133,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 1210
 Content-Type: application/json

--- a/develop/update-a-customer-s-usage-spending-budget.md
+++ b/develop/update-a-customer-s-usage-spending-budget.md
@@ -118,7 +118,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 12014
 Content-Type: application/json

--- a/develop/update-a-list-of-devices-with-a-policy.md
+++ b/develop/update-a-list-of-devices-with-a-policy.md
@@ -156,7 +156,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 202 Accepted
 Content-Length: 0
 Location: /customers/c7f3c849-129f-4b85-a96d-4f8e88b315a3/batchJobStatus/a15f3996-620a-4404-9f1f-4c2de78de0de

--- a/develop/update-a-service-request.md
+++ b/develop/update-a-service-request.md
@@ -130,7 +130,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 566
 Content-Type: application/json; charset=utf-8

--- a/develop/update-a-subscription-s-support-contact.md
+++ b/develop/update-a-subscription-s-support-contact.md
@@ -125,7 +125,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 328
 Content-Type: application/json; charset=utf-8

--- a/develop/update-an-organization-profile.md
+++ b/develop/update-an-organization-profile.md
@@ -119,7 +119,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 648
 Content-Type: application/json; charset=utf-8

--- a/develop/update-legal-business-profile.md
+++ b/develop/update-legal-business-profile.md
@@ -139,7 +139,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 1157
 Content-Type: application/json; charset=utf-8

--- a/develop/update-partner-billing-profile.md
+++ b/develop/update-partner-billing-profile.md
@@ -121,7 +121,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 568
 Content-Type: application/json; charset=utf-8

--- a/develop/update-support-profile.md
+++ b/develop/update-support-profile.md
@@ -102,7 +102,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 502
 Content-Type: application/json

--- a/develop/update-the-nickname-for-a-subscription.md
+++ b/develop/update-the-nickname-for-a-subscription.md
@@ -126,7 +126,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 PATCH http://partnerapi.store.microsoft.com/v1/customers/<customer-tenant-id>/subscriptions/<subscriptionID> HTTP/1.1
 Authorization: Bearer <token>
 Accept: application/json

--- a/develop/update-user-accounts-for-a-customer.md
+++ b/develop/update-user-accounts-for-a-customer.md
@@ -109,7 +109,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 31942
 Content-Type: application/json

--- a/develop/upload-a-list-of-devices-for-the-specified-customer.md
+++ b/develop/upload-a-list-of-devices-for-the-specified-customer.md
@@ -161,7 +161,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 202 Accepted
 Content-Length: 0
 Location: /customers/c7f3c849-129f-4b85-a96d-4f8e88b315a3/batchJobStatus/16c00110-e79a-433d-aa28-f69dd60df671

--- a/develop/upload-a-list-of-devices-to-create-a-new-batch-for-the-specified-customer.md
+++ b/develop/upload-a-list-of-devices-to-create-a-new-batch-for-the-specified-customer.md
@@ -145,7 +145,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 202 Accepted
 Content-Length: 0
 Location: /customers/c7f3c849-129f-4b85-a96d-4f8e88b315a3/batchJobStatus/beba2053-5401-46ff-9223-7e841ed78fbf

--- a/develop/view-a-deleted-user.md
+++ b/develop/view-a-deleted-user.md
@@ -105,7 +105,7 @@ Each response comes with an HTTP status code that indicates success or failure a
 
 **Response example**
 
-``` json
+```http
 HTTP/1.1 200 OK
 Content-Length: 802
 Content-Type: application/json; charset=utf-8


### PR DESCRIPTION
Several of the HTTP response samples did not have a code type specified. Other that did used a type of JSON instead of HTTP. Using HTTP will get docs.microsoft.com to apply the correct syntax highlighting to the sample. Also, I removed blank lines from the end of several files.