### PR TITLE
Fix formatting in get-invoice-unbilled-recon-lineitems.md

### DIFF
--- a/develop/get-invoice-unbilled-recon-lineitems.md
+++ b/develop/get-invoice-unbilled-recon-lineitems.md
@@ -231,7 +231,7 @@ Date: Wed, 20 Feb 2019 19:59:27 GMT
             "pcToBCExchangeRate": 1,
             "pcToBCExchangeRateDate": "2019-08-01T00:00:00Z",
             "billableQuantity": 3.1618,
-			"meterDescription": "Bandwidth - Data Transfer In (GB) - Zone 2",
+	    "meterDescription": "Bandwidth - Data Transfer In (GB) - Zone 2",
             "attributes": {
                 "objectType": "OneTimeInvoiceLineItem"
             }
@@ -275,7 +275,7 @@ Date: Wed, 20 Feb 2019 19:59:27 GMT
             "pcToBCExchangeRate": 1,
             "pcToBCExchangeRateDate": "2019-08-01T00:00:00Z",
             "billableQuantity": 0.737083,
-			"meterDescription": "",
+	    "meterDescription": "",
             "attributes": {
                 "objectType": "OneTimeInvoiceLineItem"
             }
@@ -392,6 +392,7 @@ Date: Wed, 20 Feb 2019 19:59:27 GMT
         "objectType": "Collection"
     }
 }
+```
 
 #### Request example 3
 
@@ -462,7 +463,7 @@ Date: Wed, 20 Feb 2019 19:59:27 GMT
             "discountDetails": "",
             "providerSource": "All",
             "RateOfPartnerEarnedCredit": 0.15,
-            "IsPartnerEarnedCreditApplied": true
+            "IsPartnerEarnedCreditApplied": true,
             "attributes": {
                 "objectType": "OneTimeInvoiceLineItem"
             }


### PR DESCRIPTION
There was a markdown formatting issue in the REST section that was causing `Request example 3` to be rendered as a part of the `Response example 2` code block. I also took the opportunity to fix an error in the JSON blobs, as well as a few inconsistencies in indentation.