### PR TITLE
added transfer scenarios documentation

### DIFF
--- a/develop/accept-a-transfer.md
+++ b/develop/accept-a-transfer.md
@@ -1,0 +1,203 @@
+---
+title: Accept a transfer
+description: How to accept a transfer of subscriptions for a customer.
+ms.date: 04/03/2020
+ms.service: partner-dashboard
+ms.subservice:  partnercenter-csp
+ms.localizationpriority: medium
+---
+
+# Create a transfer
+
+Applies to:
+
+- Partner Center
+- Partner Center operated by 21Vianet
+- Partner Center for Microsoft Cloud Germany
+- Partner Center for Microsoft Cloud for US Government
+
+
+## Prerequisites
+
+- Credentials as described in [Partner Center authentication](partner-center-authentication.md). This scenario supports authentication with both standalone App and App+User credentials.
+- A customer identifier. If you do not have a customer's ID, you can look up the ID in Partner Center by choosing the customer from the customers list, selecting Account, then saving their Microsoft ID.
+- A transfer identifier for an existing transfer.
+
+## REST request
+
+### Request syntax
+
+| Method   | Request URI                                                                                                 |
+|----------|-------------------------------------------------------------------------------------------------------------|
+| **POST** | [*{baseURL}*](partner-center-rest-urls.md)/v1/customers/{customer-id}/transfers/{transfer-id}/accept HTTP/1.1                    |
+
+### URI parameter
+
+Use the following path parameter to identify the customer and specify the transfer to be accepted.
+
+| Name            | Type     | Required | Description                                                            |
+|-----------------|----------|----------|------------------------------------------------------------------------|
+| **customer-id** | string   | Yes      | A GUID formatted customer-id that identifies the customer.             |
+| **transfer-id** | string   | Yes      | A GUID formatted transfer-id that identifies the transfer.             |
+
+### Request headers
+
+See [Partner Center REST headers](headers.md) for more information.
+
+### Request example
+
+```http
+POST /v1/customers/d6bf25b7-e0a8-4f2d-a31b-97b55cfc774d/transfers/aa2bddb6-9cc8-4949-80fe-a37d5e0a13ba/accept HTTP/1.1
+Authorization: Bearer <token>
+Accept: application/json
+MS-CorrelationId: 4827b753-8541-428b-8c90-059b6b4851bd
+MS-RequestId: 8389053b-731c-4261-9899-1583d7859153
+X-Locale: en-US
+Content-Type: application/json
+Host: api.partnercenter.microsoft.com
+Content-Length: 0
+
+```
+
+## REST response
+
+If successful, this method returns the populated [TransferSubmitResult](transfer-entity-resources.md##transferSubmitResult) resource in the response body.
+
+### Response success and error codes
+
+Each response comes with an HTTP status code that indicates success or failure and additional debugging information. Use a network trace tool to read this code, error type, and additional parameters. For the full list, see [Error Codes](error-codes.md).
+
+### Response example
+
+```http
+HTTP/1.1 200 OK
+Content-Length: 3389
+Content-Type: application/json; charset=utf-8
+MS-CorrelationId: 4827b753-8541-428b-8c90-059b6b4851bd
+MS-RequestId: 8389053b-731c-4261-9899-1583d7859153
+X-Locale: en-US
+Date: Wed, 25 Mar 2020 19:13:06 GMT
+
+{
+  "orders": [
+    {
+      "id": "21b92393-ffce-4bc7-87c5-62cfa897d8f9",
+      "alternateId": "21b92393-ffce-4bc7-87c5-62cfa897d8f9",
+      "referenceCustomerId": "b67f0b00-f9e8-4c57-bcb5-0b8b95c6ccf0",
+      "billingCycle": "annual",
+      "currencyCode": "USD",
+      "lineItems": [
+        {
+          "lineItemNumber": 0,
+          "offerId": "5344C201-3099-44E5-B333-C3EB0401EDE0",
+          "termDuration": "P1Y",
+          "transactionType": "New",
+          "friendlyName": "Dynamics 365 Customer Engagement Plan (36 mo)",
+          "quantity": 1,
+          "partnerIdOnRecord": "5139005",
+          "links": {
+            
+          }
+        }
+      ],
+      "creationDate": "2020-03-25T22:24:23.183+00:00",
+      "status": "completed",
+      "transactionType": "UserPurchase",
+      "links": {
+        "self": {
+          "uri": "/customers/b67f0b00-f9e8-4c57-bcb5-0b8b95c6ccf0/orders/21b92393-ffce-4bc7-87c5-62cfa897d8f9",
+          "method": "GET",
+          "headers": [
+            
+          ]
+        },
+        "patchOperation": {
+          "uri": "/customers/b67f0b00-f9e8-4c57-bcb5-0b8b95c6ccf0/orders/21b92393-ffce-4bc7-87c5-62cfa897d8f9",
+          "method": "PATCH",
+          "headers": [
+            
+          ]
+        }
+      },
+      "attributes": {
+        "etag": "eyJpZCI6IjIxYjkyMzkzLWZmY2UtNGJjNy04N2M1LTYyY2ZhODk3ZDhmOSIsInZlcnNpb24iOjF9",
+        "objectType": "Order"
+      }
+    },
+    {
+      "id": "7414b8ea-c167-4cc4-bc8e-b43efc177a46",
+      "alternateId": "7414b8ea-c167-4cc4-bc8e-b43efc177a46",
+      "referenceCustomerId": "b67f0b00-f9e8-4c57-bcb5-0b8b95c6ccf0",
+      "billingCycle": "annual",
+      "currencyCode": "USD",
+      "lineItems": [
+        {
+          "lineItemNumber": 0,
+          "offerId": "1A90EE13-2CB4-4785-BB0F-542813F00A37",
+          "termDuration": "P1Y",
+          "transactionType": "New",
+          "friendlyName": "Dynamics 365 Business Central Essential",
+          "quantity": 1,
+          "partnerIdOnRecord": "5139005",
+          "links": {
+            
+          }
+        }
+      ],
+      "creationDate": "2020-03-25T22:24:34.59+00:00",
+      "status": "completed",
+      "transactionType": "UserPurchase",
+      "links": {
+        "self": {
+          "uri": "/customers/b67f0b00-f9e8-4c57-bcb5-0b8b95c6ccf0/orders/7414b8ea-c167-4cc4-bc8e-b43efc177a46",
+          "method": "GET",
+          "headers": [
+            
+          ]
+        },
+        "patchOperation": {
+          "uri": "/customers/b67f0b00-f9e8-4c57-bcb5-0b8b95c6ccf0/orders/7414b8ea-c167-4cc4-bc8e-b43efc177a46",
+          "method": "PATCH",
+          "headers": [
+            
+          ]
+        }
+      },
+      "attributes": {
+        "etag": "eyJpZCI6Ijc0MTRiOGVhLWMxNjctNGNjNC1iYzhlLWI0M2VmYzE3N2E0NiIsInZlcnNpb24iOjF9",
+        "objectType": "Order"
+      }
+    }
+  ],
+  "transferErrors": [
+    {
+      "transferGroupId": "1",
+      "lineItems": [
+        {
+          "id": 1,
+          "subscriptionId": "637FF8F6-D842-4573-8DA8-89765356CD1A",
+          "entitlementId": "637FF8F6-D842-4573-8DA8-89765356CD1A",
+          "offerId": "A4179D30-CC09-49F0-977E-DC2CB70B874F",
+          "friendlyName": "Project Online Essentials",
+          "quantity": 1,
+          "transferGroupId": "1",
+          "addonItems": [
+            
+          ],
+          "partnerIdOnRecord": "5139005",
+          "billingCycle": "annual",
+          "sourceSubscriptionId": "637FF8F6-D842-4573-8DA8-89765356CD1A"
+        }
+      ],
+      "code": 900103,
+      "description": "Subscription SyncState must be SyncComplete for the Subscription to be a source in a Subscription Ownership Transfer. Subscription: 637ff8f6-d842-4573-8da8-89765356cd1a, current state: None",
+      "attributes": {
+        "objectType": "TransferError"
+      }
+    }
+  ],
+  "attributes": {
+    "objectType": "TransferSubmitResult"
+  }
+}
+```

--- a/develop/create-a-transfer.md
+++ b/develop/create-a-transfer.md
@@ -1,0 +1,178 @@
+---
+title: Create a transfer
+description: How to create a transfer of subscriptions for a customer.
+ms.date: 04/03/2020
+ms.service: partner-dashboard
+ms.subservice:  partnercenter-csp
+ms.localizationpriority: medium
+---
+
+# Create a transfer
+
+Applies to:
+
+- Partner Center
+- Partner Center operated by 21Vianet
+- Partner Center for Microsoft Cloud Germany
+- Partner Center for Microsoft Cloud for US Government
+
+
+## Prerequisites
+
+- Credentials as described in [Partner Center authentication](partner-center-authentication.md). This scenario supports authentication with both standalone App and App+User credentials.
+- A customer identifier. If you do not have a customer's ID, you can look up the ID in Partner Center by choosing the customer from the customers list, selecting Account, then saving their Microsoft ID.
+
+## REST request
+
+### Request syntax
+
+| Method   | Request URI                                                                                                 |
+|----------|-------------------------------------------------------------------------------------------------------------|
+| **POST** | [*{baseURL}*](partner-center-rest-urls.md)/v1/customers/{customer-id}/transfers HTTP/1.1                    |
+
+### URI parameter
+
+Use the following path parameter to identify the customer.
+
+| Name            | Type     | Required | Description                                                            |
+|-----------------|----------|----------|------------------------------------------------------------------------|
+| **customer-id** | string   | Yes      | A GUID formatted customer-id that identifies the customer.             |
+
+### Request headers
+
+See [Partner Center REST headers](headers.md) for more information.
+
+### Request body
+
+This table describes the [TransferEntity](transfer-resources.md) properties in the request body.
+
+| Property              | Type          | Required  | Description                                                                                |
+|-----------------------|---------------|-----------|--------------------------------------------------------------------------------------------|
+| id                    | string        | No    | A transferEntity identifier that is supplied upon successful creation of the transferEntity.                               |
+| createdTime           | DateTime      | No    | The date the transferEntity was created, in date-time format. Applied upon successful creation of the transferEntity.      |
+| lastModifiedTime      | DateTime      | No    | The date the transferEntity was last updated, in date-time format. Applied upon successful creation of the transferEntity. |
+| lastModifiedUser      | string        | No    | The user who last updated the transferEntity. Applied upon successful creation of transferEntity.                          |
+| customerName          | string        | No    | Optional. The name of the customer whose subscriptions are being transferred.                                              |
+| customerTenantId      | string        | No    | A GUID formatted customer-id that identifies the customer. Applied upon successful creation of the transferEntity.         |
+| partnertenantid       | string        | No    | A GUID formatted partner-id that identifies the partner.                                                                   |
+| sourcePartnerName     | string        | No    | Optional. The name of the partner's organization who is initiating the transfer.                                           |
+| sourcePartnerTenantId | string        | Yes   | A GUID formatted partner-id that identifies the partner initiating the transfer.                                           |
+| targetPartnerName     | string        | No    | Optional. The name of the partner's organization to whom the transfer is targeted.                                         |
+| targetPartnerTenantId | string        | Yes   | A GUID formatted partner-id that identifies the partner to whom the transfer is targeted.                                  |
+| lineItems             | Array of objects | Yes| An Array of [TransferLineItem](#transferlineitem) resources.                                                               |
+| status                | string        | No    | The status of the transferEntity. Possible values are "Active" (can be deleted/submitted) and "Completed" (has already been completed). Applied upon successful creation of the transferEntity.|
+
+This table describes the [TransferLineItem](transfer-entity-resources.md#transferlineitem) properties in the request body.
+
+|      Property       |            Type             | Required | Description                                                                                     |
+|---------------------|-----------------------------|----------|-------------------------------------------------------------------------------------------------|
+| id                   | string                     | No       | A unique identifier for a transfer line item. Applied upon successful creation of the transferEntity.|
+| subscriptionId       | string                     | Yes      | The subscription identifier.                                                                         |
+| quantity             | int                        | No       | The number of licenses or instances.                                                                 |
+| billingCycle         | Object                     | No       | The type of billing cycle set for the current period.                                                |
+| friendlyName         | string                     | No       | Optional. The friendly name for the item defined by the partner to help disambiguate.                |
+| partnerIdOnRecord    | string                     | No       | PartnerId on Record (MPNID) on the purchase that happens when the transfer is accepted.              |
+| offerId              | string                     | No       | The offer identifier.                                                                                |
+| addonItems           | List of **TransferLineItem** objects | No | A collection of transferEntity line items for addons that will be transferred along with the base subscription that is being transferred. Applied upon successful creation of the transferEntity.|
+| transferError        | string                     | No       | Applied after transferEntity is accepted in case of an error.                                        |
+| status               | string                     | No       | The status of the lineitem in the transferEntity.                                                    |
+
+
+
+### Request example
+
+```http
+POST /v1/customers/d6bf25b7-e0a8-4f2d-a31b-97b55cfc774d/transfers HTTP/1.1
+Authorization: Bearer <token>
+Accept: application/json
+MS-RequestId: 4fa6dad6-a89f-4875-8247-7294a10ae1cf
+MS-CorrelationId: 0e93c70c-977c-4a88-9580-7cf084c73286
+X-Locale: en-US
+Content-Type: application/json
+Host: api.partnercenter.microsoft.com
+Expect: 100-continue
+
+{
+    "sourcePartnerTenantId": "da6c51b5-1246-4a42-b4ab-cbf38df54537",
+    "targetPartnerTenantId": "656218b1-80c9-40b2-83ae-3a2703b55271",
+    "lineItems": [
+        {
+            "subscriptionId": "7291BFBF-1772-4C5B-A624-18B6152CD8CB",
+            "partnerIdOnRecord": "517285"
+        },
+        {
+            "subscriptionId": "6C0B221B-8DF9-4F4A-A5BB-4C9CBB7B27B0",
+            "partnerIdOnRecord": "517285"
+        }
+    ]
+}
+```
+
+## REST response
+
+If successful, this method returns the populated [TransferEnity](transfer-entity-resources.md) resource in the response body.
+
+### Response success and error codes
+
+Each response comes with an HTTP status code that indicates success or failure and additional debugging information. Use a network trace tool to read this code, error type, and additional parameters. For the full list, see [Error Codes](error-codes.md).
+
+### Response example
+
+```http
+HTTP/1.1 201 Created
+Content-Length: 138
+Content-Type: application/json; charset=utf-8
+MS-RequestId: 4fa6dad6-a89f-4875-8247-7294a10ae1cf
+MS-CorrelationId: 0e93c70c-977c-4a88-9580-7cf084c73286
+X-Locale: en-US,en-US
+{
+    "id": "67c5b05b-09b5-47ba-9047-5056fe2afa4f",
+    "status": "Active",
+    "createdTime": "2020-03-24T20:44:14.9602781Z",
+    "lastModifiedTime": "2020-03-24T20:44:15Z",
+    "customerTenantId": "823c6c3f-9259-4d51-bae2-5dd06743177f",
+    "partnertenantid": "da6c51b5-1246-4a42-b4ab-cbf38df54537",
+    "sourcePartnerTenantId": "da6c51b5-1246-4a42-b4ab-cbf38df54537",
+    "targetPartnerTenantId": "656218b1-80c9-40b2-83ae-3a2703b55271",
+    "lastModifiedUser": "d0648481-b615-45c9-8cd1-ff87940dbdc4",
+    "lineItems": [
+        {
+            "id": 0,
+            "subscriptionId": "7291BFBF-1772-4C5B-A624-18B6152CD8CB",
+            "offerId": "50E9A47A-7B4D-4970-9D90-CAE927F53753",
+            "billingCycle": "annual",
+            "friendlyName": "Dynamics 365 for Sales Enterprise Attach to Qualifying Dynamics 365 Base Offer",
+            "quantity": 1,
+            "addonItems": [
+                {
+                    "id": 0,
+                    "subscriptionId": "D738C6C9-DDBD-46E9-B316-65F9D9B3ECB4",
+                    "offerId": "2BCF9FE8-8B65-4FCF-9240-419203FB8CF4",
+                    "billingCycle": "annual",
+                    "friendlyName": "Dynamics 365 - Additional Production Instance (Qualified Offer)",
+                    "quantity": 4
+                }
+            ]
+        },
+        {
+            "id": 0,
+            "subscriptionId": "6C0B221B-8DF9-4F4A-A5BB-4C9CBB7B27B0",
+            "offerId": "455DDD41-32ED-4E2D-B3A2-BBCB22CAA467",
+            "billingCycle": "annual",
+            "friendlyName": "Dynamics 365 Customer Engagement Plan Patch",
+            "quantity": 8,
+            "addonItems": []
+        }
+    ],
+    "links": {
+        "self": {
+            "uri": "/customers/823c6c3f-9259-4d51-bae2-5dd06743177f/transfers/67c5b05b-09b5-47ba-9047-5056fe2afa4f",
+            "method": "GET",
+            "headers": []
+        }
+    },
+    "attributes": {
+        "objectType": "TransferEntity"
+    }
+}
+```

--- a/develop/get-all-of-a-customer-s-transfers.md
+++ b/develop/get-all-of-a-customer-s-transfers.md
@@ -1,0 +1,592 @@
+---
+title: Get a customer's transfers
+description: How to get a list of a customer's transfers.
+ms.date: 04/03/2020
+ms.service: partner-dashboard
+ms.subservice:  partnercenter-csp
+ms.localizationpriority: medium
+---
+
+# Get a customer's transfers
+
+
+**Applies To**
+
+- Partner Center
+- Partner Center operated by 21Vianet
+- Partner Center for Microsoft Cloud Germany
+- Partner Center for Microsoft Cloud for US Government
+
+How to get a list of a customer's transfers.
+
+## <span id="Prerequisites"/><span id="prerequisites"/><span id="PREREQUISITES"/>Prerequisites
+
+
+- Credentials as described in [Partner Center authentication](partner-center-authentication.md). This scenario supports authentication with both standalone App and App+User credentials.
+- A customer identifier.
+
+**Request syntax**
+
+| Method  | Request URI                                                                                          |
+|---------|------------------------------------------------------------------------------------------------------|
+| **GET** | [*{baseURL}*](partner-center-rest-urls.md)/v1/customers/{customer-tenant-id}/transfers HTTP/1.1 |
+
+ 
+
+**URI parameter**
+
+This table lists the required query parameter to get all the subscriptions.
+
+| Name               | Type   | Required | Description                                           |
+|--------------------|--------|----------|-------------------------------------------------------|
+| customer-tenant-id | string | Yes      | A GUID-formatted string that identifies the customer. |
+
+ 
+
+**Request headers**
+
+- See [Partner Center REST headers](headers.md) for more information.
+
+**Request body**
+
+None.
+
+**Request example**
+
+```http
+GET /v1/customers/b67f0b00-f9e8-4c57-bcb5-0b8b95c6ccf0/transfers HTTP/1.1
+Authorization: Bearer <token>
+Accept: application/json
+MS-RequestId: ca2cdd2c-7eb8-4a2e-cdd7-2848752e801a
+MS-CorrelationId: dec58181-67b5-4831-c2c9-2fa099122f5d
+Connection: Keep-Alive
+```
+
+## <span id="Response"/><span id="response"/><span id="RESPONSE"/>Response
+
+
+If successful, this method returns a list of [TransferEntity](transfer-entity-resources.md) resources in the response body.
+
+**Response success and error codes**
+
+Each response comes with an HTTP status code that indicates success or failure and additional debugging information. Use a network trace tool to read this code, error type, and additional parameters. For the full list, see [Partner Center REST error codes](error-codes.md).
+
+**Response example**
+
+```http
+HTTP/1.1 200 OK
+Content-Length: 13828
+Content-Type: application/json
+MS-CorrelationId: dec58181-67b5-4831-c2c9-2fa099122f5d
+MS-RequestId: ca2cdd2c-7eb8-4a2e-cdd7-2848752e801a
+Date: Fri, 27 Mar 2020 17:50:34 GMT
+
+[
+  {
+    "id": "ab724652-3442-4912-8615-61525bb9903d",
+    "status": "Reject",
+    "createdTime": "2019-10-09T22:44:13.5411441Z",
+    "lastModifiedTime": "2020-02-20T21:27:59Z",
+    "customerTenantId": "b67f0b00-f9e8-4c57-bcb5-0b8b95c6ccf0",
+    "partnertenantid": "3a9a35ce-d5be-4814-ab58-4451c36fe157",
+    "sourcePartnerName": "Test_Test_09092019GBL",
+    "sourcePartnerTenantId": "7c8db11f-1e5e-4472-8386-f0b627d1f3e1",
+    "targetPartnerName": "Test_Test_09032019GBL",
+    "targetPartnerTenantId": "3a9a35ce-d5be-4814-ab58-4451c36fe157",
+    "lastModifiedUser": "edc0524d-2e42-4619-af7e-349c015cfdfd",
+    "lineItems": [
+      {
+        "id": 0,
+        "subscriptionId": "586DFB1A-E65C-48F4-BF6C-0D62D68AF1D0",
+        "offerId": "B4D4B7F4-4089-43B6-9C44-DE97B760FB11",
+        "billingCycle": "monthly",
+        "friendlyName": "Visio Online Plan 2",
+        "quantity": 1,
+        "partnerIdOnRecord": "5139005",
+        "addonItems": [
+          
+        ]
+      },
+      {
+        "id": 0,
+        "subscriptionId": "1151B8CE-125C-49D7-8C48-E62FC9101B77",
+        "offerId": "13D32E13-A1B0-400D-96C0-4EAAA14DCED5",
+        "billingCycle": "monthly",
+        "friendlyName": "Dynamics 365 for Supply Chain Management Attach to Qualifying Dynamics 365 Base Offer (Qualified Offer)",
+        "quantity": 20,
+        "partnerIdOnRecord": "5139005",
+        "addonItems": [
+          
+        ]
+      }
+    ],
+    "links": {
+      "self": {
+        "uri": "/customers/b67f0b00-f9e8-4c57-bcb5-0b8b95c6ccf0/transfers/ab724652-3442-4912-8615-61525bb9903d",
+        "method": "GET",
+        "headers": [
+          
+        ]
+      }
+    },
+    "attributes": {
+      "objectType": "TransferEntity"
+    }
+  },
+  {
+    "id": "38a00d97-421c-4c33-8ae4-c8750604e02c",
+    "status": "Complete",
+    "createdTime": "2020-02-20T21:16:30.0149083Z",
+    "lastModifiedTime": "2020-02-27T01:11:33Z",
+    "customerTenantId": "b67f0b00-f9e8-4c57-bcb5-0b8b95c6ccf0",
+    "partnertenantid": "3a9a35ce-d5be-4814-ab58-4451c36fe157",
+    "sourcePartnerName": "Test_Test_09092019GBL",
+    "sourcePartnerTenantId": "7c8db11f-1e5e-4472-8386-f0b627d1f3e1",
+    "targetPartnerName": "Test_Test_09032019GBL",
+    "targetPartnerTenantId": "3a9a35ce-d5be-4814-ab58-4451c36fe157",
+    "lastModifiedUser": "edc0524d-2e42-4619-af7e-349c015cfdfd",
+    "lineItems": [
+      {
+        "id": 0,
+        "subscriptionId": "25339C80-8C79-49A8-8C38-C98A80F4D3A5",
+        "offerId": "5E1087B6-246B-4503-B88A-B60BDF0B3840",
+        "orderId": "5761e79a-f441-4a18-9902-83f9582ccff6",
+        "billingCycle": "monthly",
+        "friendlyName": "PowerApps per app plan",
+        "quantity": 1,
+        "partnerIdOnRecord": "5139005",
+        "transferGroupId": "0",
+        "status": "Complete",
+        "addonItems": [
+          
+        ]
+      },
+      {
+        "id": 0,
+        "subscriptionId": "FE2EA4C8-88EA-41DC-BC2F-76195E282202",
+        "offerId": "91FD106F-4B2C-4938-95AC-F54F74E9A239",
+        "orderId": "9a088a06-dfe5-4f71-ba79-2711c313b634",
+        "billingCycle": "monthly",
+        "friendlyName": "Office 365 E1",
+        "quantity": 1,
+        "partnerIdOnRecord": "5139005",
+        "transferGroupId": "1",
+        "status": "Complete",
+        "addonItems": [
+          
+        ]
+      },
+      {
+        "id": 0,
+        "subscriptionId": "D6C8BF37-CE99-46E1-A64F-329F1971F54D",
+        "offerId": "MS-AZR-0145P",
+        "orderId": "6a9a544c-54c9-43e9-a863-b40c6f92d111",
+        "billingCycle": "monthly",
+        "friendlyName": "Microsoft Azure",
+        "quantity": 1,
+        "partnerIdOnRecord": "5139005",
+        "transferGroupId": "2",
+        "status": "Complete",
+        "addonItems": [
+          
+        ]
+      }
+    ],
+    "links": {
+      "self": {
+        "uri": "/customers/b67f0b00-f9e8-4c57-bcb5-0b8b95c6ccf0/transfers/38a00d97-421c-4c33-8ae4-c8750604e02c",
+        "method": "GET",
+        "headers": [
+          
+        ]
+      }
+    },
+    "attributes": {
+      "objectType": "TransferEntity"
+    }
+  },
+  {
+    "id": "d4f478d2-61e0-4550-b85d-c427abfe1e62",
+    "status": "Complete",
+    "createdTime": "2020-02-20T21:28:55.4245587Z",
+    "lastModifiedTime": "2020-02-20T21:29:22Z",
+    "customerTenantId": "b67f0b00-f9e8-4c57-bcb5-0b8b95c6ccf0",
+    "partnertenantid": "3a9a35ce-d5be-4814-ab58-4451c36fe157",
+    "sourcePartnerName": "Test_Test_09092019GBL",
+    "sourcePartnerTenantId": "7c8db11f-1e5e-4472-8386-f0b627d1f3e1",
+    "targetPartnerName": "Test_Test_09032019GBL",
+    "targetPartnerTenantId": "3a9a35ce-d5be-4814-ab58-4451c36fe157",
+    "lastModifiedUser": "edc0524d-2e42-4619-af7e-349c015cfdfd",
+    "lineItems": [
+      {
+        "id": 0,
+        "subscriptionId": "586DFB1A-E65C-48F4-BF6C-0D62D68AF1D0",
+        "offerId": "B4D4B7F4-4089-43B6-9C44-DE97B760FB11",
+        "orderId": "2340952e-af72-40e6-a106-e9b2aca99bb5",
+        "billingCycle": "monthly",
+        "friendlyName": "Visio Online Plan 2",
+        "quantity": 2,
+        "partnerIdOnRecord": "5139005",
+        "transferGroupId": "0",
+        "status": "Complete",
+        "addonItems": [
+          
+        ]
+      },
+      {
+        "id": 0,
+        "subscriptionId": "6D63E69C-7551-4E37-B7F6-87AC124B3235",
+        "offerId": "F1A2FDB0-5CA8-475D-8CCC-9BB81C033DA5",
+        "orderId": "5dd120ab-10a4-4bbf-b2bd-e52657431f85",
+        "billingCycle": "monthly",
+        "friendlyName": "Dynamics 365 for Project Service Automation (Qualified Offer) (250 seat minimum requirement)",
+        "quantity": 250,
+        "partnerIdOnRecord": "5139005",
+        "transferGroupId": "1",
+        "status": "Complete",
+        "addonItems": [
+          
+        ]
+      }
+    ],
+    "links": {
+      "self": {
+        "uri": "/customers/b67f0b00-f9e8-4c57-bcb5-0b8b95c6ccf0/transfers/d4f478d2-61e0-4550-b85d-c427abfe1e62",
+        "method": "GET",
+        "headers": [
+          
+        ]
+      }
+    },
+    "attributes": {
+      "objectType": "TransferEntity"
+    }
+  },
+  {
+    "id": "f10421cd-d4af-4939-82b9-cd0e75022759",
+    "status": "PartiallyComplete",
+    "createdTime": "2020-02-26T21:54:51.2901506Z",
+    "lastModifiedTime": "2020-02-27T01:10:26Z",
+    "customerTenantId": "b67f0b00-f9e8-4c57-bcb5-0b8b95c6ccf0",
+    "partnertenantid": "3a9a35ce-d5be-4814-ab58-4451c36fe157",
+    "sourcePartnerName": "Test_Test_09092019GBL",
+    "sourcePartnerTenantId": "7c8db11f-1e5e-4472-8386-f0b627d1f3e1",
+    "targetPartnerName": "Test_Test_09032019GBL",
+    "targetPartnerTenantId": "3a9a35ce-d5be-4814-ab58-4451c36fe157",
+    "lastModifiedUser": "edc0524d-2e42-4619-af7e-349c015cfdfd",
+    "lineItems": [
+      {
+        "id": 0,
+        "subscriptionId": "586DFB1A-E65C-48F4-BF6C-0D62D68AF1D0",
+        "offerId": "B4D4B7F4-4089-43B6-9C44-DE97B760FB11",
+        "billingCycle": "monthly",
+        "friendlyName": "Visio Online Plan 2",
+        "quantity": 2,
+        "partnerIdOnRecord": "5139005",
+        "transferGroupId": "0",
+        "status": "Failed",
+        "addonItems": [
+          
+        ],
+        "transferError": "Subscription has already been transfered. Subscription: 586dfb1a-e65c-48f4-bf6c-0d62d68af1d0"
+      },
+      {
+        "id": 0,
+        "subscriptionId": "E9C06692-4D85-411E-8C4A-45E3D6D24EDD",
+        "offerId": "1B4642E5-C69A-43EA-B4F6-F29BAE46227E",
+        "orderId": "0e6793f0-3d9c-4749-b50d-1cf3527aa454",
+        "billingCycle": "monthly",
+        "friendlyName": "Dynamics 365 for Retail Attach to Qualifying Dynamics 365 Base Offer From SA From VL/DPL",
+        "quantity": 20,
+        "partnerIdOnRecord": "5139005",
+        "transferGroupId": "1",
+        "status": "Complete",
+        "addonItems": [
+          
+        ]
+      }
+    ],
+    "links": {
+      "self": {
+        "uri": "/customers/b67f0b00-f9e8-4c57-bcb5-0b8b95c6ccf0/transfers/f10421cd-d4af-4939-82b9-cd0e75022759",
+        "method": "GET",
+        "headers": [
+          
+        ]
+      }
+    },
+    "attributes": {
+      "objectType": "TransferEntity"
+    }
+  },
+  {
+    "id": "ddb933ad-02f4-4678-a09a-7fecca481acc",
+    "status": "Reject",
+    "createdTime": "2020-03-11T17:44:26.8841412Z",
+    "lastModifiedTime": "2020-03-11T17:45:08Z",
+    "customerTenantId": "b67f0b00-f9e8-4c57-bcb5-0b8b95c6ccf0",
+    "partnertenantid": "3a9a35ce-d5be-4814-ab58-4451c36fe157",
+    "sourcePartnerName": "Test_Test_09092019GBL",
+    "sourcePartnerTenantId": "7c8db11f-1e5e-4472-8386-f0b627d1f3e1",
+    "targetPartnerName": "Test_Test_09032019GBL",
+    "targetPartnerTenantId": "3a9a35ce-d5be-4814-ab58-4451c36fe157",
+    "lastModifiedUser": "01a7548d-1136-4cf0-ba9a-300f921ffb22",
+    "lineItems": [
+      {
+        "id": 0,
+        "subscriptionId": "68ECA8B4-A5E7-4245-94FB-A7A81F3B7234",
+        "offerId": "5B04B78C-FD36-4CF3-A7A5-3457991C8B79",
+        "billingCycle": "monthly",
+        "friendlyName": "Dynamics 365 Business Central Device",
+        "quantity": 1,
+        "partnerIdOnRecord": "5139005",
+        "addonItems": [
+          
+        ]
+      },
+      {
+        "id": 1,
+        "subscriptionId": "F09A8540-AE89-4B08-8967-1ECB92FEE35B",
+        "offerId": "MS-AZR-0145P",
+        "billingCycle": "monthly",
+        "friendlyName": "Microsoft Azure",
+        "quantity": 1,
+        "partnerIdOnRecord": "5139005",
+        "addonItems": [
+          
+        ]
+      }
+    ],
+    "links": {
+      "self": {
+        "uri": "/customers/b67f0b00-f9e8-4c57-bcb5-0b8b95c6ccf0/transfers/ddb933ad-02f4-4678-a09a-7fecca481acc",
+        "method": "GET",
+        "headers": [
+          
+        ]
+      }
+    },
+    "attributes": {
+      "objectType": "TransferEntity"
+    }
+  },
+  {
+    "id": "0a25bd0e-e6c1-40ac-9e96-40b56d46e902",
+    "status": "Complete",
+    "createdTime": "2020-03-11T17:56:53.622599Z",
+    "lastModifiedTime": "2020-03-11T17:58:00Z",
+    "customerTenantId": "b67f0b00-f9e8-4c57-bcb5-0b8b95c6ccf0",
+    "partnertenantid": "3a9a35ce-d5be-4814-ab58-4451c36fe157",
+    "sourcePartnerName": "Test_Test_09092019GBL",
+    "sourcePartnerTenantId": "7c8db11f-1e5e-4472-8386-f0b627d1f3e1",
+    "targetPartnerName": "Test_Test_09032019GBL",
+    "targetPartnerTenantId": "3a9a35ce-d5be-4814-ab58-4451c36fe157",
+    "lastModifiedUser": "edc0524d-2e42-4619-af7e-349c015cfdfd",
+    "lineItems": [
+      {
+        "id": 0,
+        "subscriptionId": "68ECA8B4-A5E7-4245-94FB-A7A81F3B7234",
+        "offerId": "5B04B78C-FD36-4CF3-A7A5-3457991C8B79",
+        "orderId": "42436b2f-d417-4642-bb76-feb697184100",
+        "billingCycle": "monthly",
+        "friendlyName": "Dynamics 365 Business Central Device",
+        "quantity": 1,
+        "partnerIdOnRecord": "5139005",
+        "transferGroupId": "0",
+        "status": "Complete",
+        "addonItems": [
+          
+        ]
+      },
+      {
+        "id": 1,
+        "subscriptionId": "F09A8540-AE89-4B08-8967-1ECB92FEE35B",
+        "offerId": "MS-AZR-0145P",
+        "orderId": "d9a1b396-ad2c-4283-a9fe-5490acd0ce7d",
+        "billingCycle": "monthly",
+        "friendlyName": "Microsoft Azure",
+        "quantity": 1,
+        "partnerIdOnRecord": "5139005",
+        "transferGroupId": "1",
+        "status": "Complete",
+        "addonItems": [
+          
+        ]
+      }
+    ],
+    "links": {
+      "self": {
+        "uri": "/customers/b67f0b00-f9e8-4c57-bcb5-0b8b95c6ccf0/transfers/0a25bd0e-e6c1-40ac-9e96-40b56d46e902",
+        "method": "GET",
+        "headers": [
+          
+        ]
+      }
+    },
+    "attributes": {
+      "objectType": "TransferEntity"
+    }
+  },
+  {
+    "id": "8dc673dd-d6a6-4739-9e8f-0b66bbf2a2c8",
+    "status": "Complete",
+    "createdTime": "2020-03-19T23:21:03.2754503Z",
+    "lastModifiedTime": "2020-03-19T23:22:33Z",
+    "customerTenantId": "b67f0b00-f9e8-4c57-bcb5-0b8b95c6ccf0",
+    "partnertenantid": "3a9a35ce-d5be-4814-ab58-4451c36fe157",
+    "sourcePartnerName": "Test_Test_09092019GBL",
+    "sourcePartnerTenantId": "7c8db11f-1e5e-4472-8386-f0b627d1f3e1",
+    "targetPartnerName": "Test_Test_09032019GBL",
+    "targetPartnerTenantId": "3a9a35ce-d5be-4814-ab58-4451c36fe157",
+    "lastModifiedUser": "3badf44d-fd41-4432-a17d-214e31f2d9ee",
+    "lineItems": [
+      {
+        "id": 0,
+        "subscriptionId": "F5B2EB56-9E0E-4160-9CEE-4218D1EEADDB",
+        "offerId": "3DD9350B-27D6-4501-93A4-C8D107F1DE47",
+        "orderId": "31bfde4a-efca-49b2-b210-62973fb773db",
+        "billingCycle": "monthly",
+        "friendlyName": "Microsoft Flow Plan 1 (Qualified Offer)",
+        "quantity": 1,
+        "partnerIdOnRecord": "5139005",
+        "transferGroupId": "0",
+        "status": "Complete",
+        "addonItems": [
+          
+        ]
+      }
+    ],
+    "links": {
+      "self": {
+        "uri": "/customers/b67f0b00-f9e8-4c57-bcb5-0b8b95c6ccf0/transfers/8dc673dd-d6a6-4739-9e8f-0b66bbf2a2c8",
+        "method": "GET",
+        "headers": [
+          
+        ]
+      }
+    },
+    "attributes": {
+      "objectType": "TransferEntity"
+    }
+  },
+  {
+    "id": "ac4a9d22-ba07-444e-890f-cfe084eed498",
+    "status": "Reject",
+    "createdTime": "2020-03-25T22:05:25.1057725Z",
+    "lastModifiedTime": "2020-03-27T17:50:32Z",
+    "customerTenantId": "b67f0b00-f9e8-4c57-bcb5-0b8b95c6ccf0",
+    "partnertenantid": "3a9a35ce-d5be-4814-ab58-4451c36fe157",
+    "sourcePartnerName": "Test_Test_09092019GBL",
+    "sourcePartnerTenantId": "7c8db11f-1e5e-4472-8386-f0b627d1f3e1",
+    "targetPartnerName": "Test_Test_09032019GBL",
+    "targetPartnerTenantId": "3a9a35ce-d5be-4814-ab58-4451c36fe157",
+    "lastModifiedUser": "01a7548d-1136-4cf0-ba9a-300f921ffb22",
+    "lineItems": [
+      {
+        "id": 0,
+        "subscriptionId": "1151B8CE-125C-49D7-8C48-E62FC9101B77",
+        "offerId": "13D32E13-A1B0-400D-96C0-4EAAA14DCED5",
+        "billingCycle": "monthly",
+        "friendlyName": "Dynamics 365 for Supply Chain Management Attach to Qualifying Dynamics 365 Base Offer (Qualified Offer)",
+        "quantity": 20,
+        "partnerIdOnRecord": "5139005",
+        "addonItems": [
+          
+        ]
+      }
+    ],
+    "links": {
+      "self": {
+        "uri": "/customers/b67f0b00-f9e8-4c57-bcb5-0b8b95c6ccf0/transfers/ac4a9d22-ba07-444e-890f-cfe084eed498",
+        "method": "GET",
+        "headers": [
+          
+        ]
+      }
+    },
+    "attributes": {
+      "objectType": "TransferEntity"
+    }
+  },
+  {
+    "id": "7b1ce5e6-5829-45c6-b3bb-89bfb791a69e",
+    "status": "PartiallyComplete",
+    "createdTime": "2020-03-25T22:20:38.8090876Z",
+    "lastModifiedTime": "2020-03-25T22:24:35Z",
+    "customerTenantId": "b67f0b00-f9e8-4c57-bcb5-0b8b95c6ccf0",
+    "partnertenantid": "3a9a35ce-d5be-4814-ab58-4451c36fe157",
+    "sourcePartnerName": "Test_Test_09092019GBL",
+    "sourcePartnerTenantId": "7c8db11f-1e5e-4472-8386-f0b627d1f3e1",
+    "targetPartnerName": "Test_Test_09032019GBL",
+    "targetPartnerTenantId": "3a9a35ce-d5be-4814-ab58-4451c36fe157",
+    "lastModifiedUser": "edc0524d-2e42-4619-af7e-349c015cfdfd",
+    "lineItems": [
+      {
+        "id": 0,
+        "subscriptionId": "2FAFDD44-1891-4EEA-9928-A07B558825C5",
+        "offerId": "5344C201-3099-44E5-B333-C3EB0401EDE0",
+        "orderId": "21b92393-ffce-4bc7-87c5-62cfa897d8f9",
+        "billingCycle": "annual",
+        "friendlyName": "Dynamics 365 Customer Engagement Plan (36 mo)",
+        "quantity": 1,
+        "partnerIdOnRecord": "5139005",
+        "transferGroupId": "0",
+        "status": "Complete",
+        "addonItems": [
+          
+        ]
+      },
+      {
+        "id": 1,
+        "subscriptionId": "637FF8F6-D842-4573-8DA8-89765356CD1A",
+        "offerId": "A4179D30-CC09-49F0-977E-DC2CB70B874F",
+        "billingCycle": "annual",
+        "friendlyName": "Project Online Essentials",
+        "quantity": 1,
+        "partnerIdOnRecord": "5139005",
+        "transferGroupId": "1",
+        "status": "Failed",
+        "addonItems": [
+          
+        ],
+        "transferError": "Subscription SyncState must be SyncComplete for the Subscription to be a source in a Subscription Ownership Transfer. Subscription: 637ff8f6-d842-4573-8da8-89765356cd1a, current state: None"
+      },
+      {
+        "id": 2,
+        "subscriptionId": "41D4FD77-1EB3-425A-BF40-88B8461D39B2",
+        "offerId": "1A90EE13-2CB4-4785-BB0F-542813F00A37",
+        "orderId": "7414b8ea-c167-4cc4-bc8e-b43efc177a46",
+        "billingCycle": "annual",
+        "friendlyName": "Dynamics 365 Business Central Essential",
+        "quantity": 1,
+        "partnerIdOnRecord": "5139005",
+        "transferGroupId": "2",
+        "status": "Complete",
+        "addonItems": [
+          
+        ]
+      }
+    ],
+    "links": {
+      "self": {
+        "uri": "/customers/b67f0b00-f9e8-4c57-bcb5-0b8b95c6ccf0/transfers/7b1ce5e6-5829-45c6-b3bb-89bfb791a69e",
+        "method": "GET",
+        "headers": [
+          
+        ]
+      }
+    },
+    "attributes": {
+      "objectType": "TransferEntity"
+    }
+  }
+]
+```
+
+ 
+
+ 
+
+
+
+

--- a/develop/get-customer-s-subscriptions-transfer-eligibility.md
+++ b/develop/get-customer-s-subscriptions-transfer-eligibility.md
@@ -1,0 +1,124 @@
+---
+title: Get a customer's subscriptions transfer eligibility
+description: How to get a collection of a customer's subscriptions that are ineligibile for transfers.
+ms.date: 04/03/2020
+ms.service: partner-dashboard
+ms.subservice:  partnercenter-csp
+ms.localizationpriority: medium
+---
+
+# Get a customer's subscriptions transfer eligibility
+
+
+**Applies To**
+
+- Partner Center
+- Partner Center operated by 21Vianet
+- Partner Center for Microsoft Cloud Germany
+- Partner Center for Microsoft Cloud for US Government
+
+How to get a collection of a customer's subscriptions.
+
+## <span id="Prerequisites"/><span id="prerequisites"/><span id="PREREQUISITES"/>Prerequisites
+
+
+- Credentials as described in [Partner Center authentication](partner-center-authentication.md). This scenario supports authentication with both standalone App and App+User credentials.
+- A customer identifier.
+
+
+## <span id="Request"/><span id="request"/><span id="REQUEST"/>Request
+
+
+**Request syntax**
+
+| Method  | Request URI                                                                                          |
+|---------|------------------------------------------------------------------------------------------------------|
+| **GET** | [*{baseURL}*](partner-center-rest-urls.md)/v1/customers/{customer-tenant-id}/transferseligibility?transferType={transfer-type} HTTP/1.1 |
+
+ 
+
+**URI parameter**
+
+This table lists the required query parameter to get all the subscriptions.
+
+| Name               | Type   | Required | Description                                           |
+|--------------------|--------|----------|-------------------------------------------------------|
+| customer-tenant-id | string | Yes      | A GUID-formatted string that identifies the customer. |
+| transfer-type      | string | Yes      | The type of transfer that is intended.                |
+
+ 
+
+**Request headers**
+
+- See [Partner Center REST headers](headers.md) for more information.
+
+**Request body**
+
+None.
+
+**Request example**
+
+```http
+GET /v1/customers/823c6c3f-9259-4d51-bae2-5dd06743177f/transferseligibility?transferType=directtoindirect HTTP/1.1
+Authorization: Bearer <token>
+Accept: application/json
+MS-RequestId: 202b5e9a-ae82-4ab9-8a0a-f4e9e04eb14d
+MS-CorrelationId: cd589c16-dc94-49ad-e529-125c258573d6
+Connection: Keep-Alive
+```
+
+## <span id="Response"/><span id="response"/><span id="RESPONSE"/>Response
+
+
+If successful, this method returns a collection of [TransferEligibility](transfer-eligibility-resources.md) resources in the response body.
+
+**Response success and error codes**
+
+Each response comes with an HTTP status code that indicates success or failure and additional debugging information. Use a network trace tool to read this code, error type, and additional parameters. For the full list, see [Partner Center REST error codes](error-codes.md).
+
+**Response example**
+
+```http
+HTTP/1.1 200 OK
+Content-Length: 73754
+Content-Type: application/json
+MS-CorrelationId: cd589c16-dc94-49ad-e529-125c258573d6
+MS-RequestId: 202b5e9a-ae82-4ab9-8a0a-f4e9e04eb14d
+Date: Tue, 24 Mar 2020 23:43:25 GMT
+
+[
+  {
+    "id": "548FA265-5F40-4765-9A6B-47826F72A4BF",
+    "isEligible": false,
+    "reason": "Subscription: 548FA265-5F40-4765-9A6B-47826F72A4BF is in state: Deleted"
+  },
+  {
+    "id": "E2A3AEB3-70A7-42E3-930C-7519EEDDC45A",
+    "isEligible": false,
+    "reason": "Subscription: E2A3AEB3-70A7-42E3-930C-7519EEDDC45A is in state: Suspended"
+  },
+  {
+    "id": "E82B2F4A-736A-4E2B-955C-C1A4C56C0171",
+    "isEligible": false,
+    "reason": "Subscription: E82B2F4A-736A-4E2B-955C-C1A4C56C0171 is in state: Deleted"
+  },
+  {
+    "id": "4B600A9A-DF56-4564-A75A-6CC6D2D0C9F9",
+    "isEligible": false,
+    "reason": "subscription is already part of another transfer request id : 31a06eac-c527-458a-a6b4-0de197a45996"
+  },
+  {
+    "id": "D3350F46-AA29-4F6F-95A0-E3011988915C",
+    "isEligible": false,
+    "reason": "Subscription: D3350F46-AA29-4F6F-95A0-E3011988915C has an independent addon: AE161D99-FA7B-418D-A453-15D6F0410C3C"
+  }
+]
+```
+
+ 
+
+ 
+
+
+
+

--- a/develop/get-transfer-by-id.md
+++ b/develop/get-transfer-by-id.md
@@ -1,0 +1,142 @@
+---
+title: Get transfer details by id
+description: How to get details of a transfer of subscriptions for a customer.
+ms.date: 04/03/2020
+ms.service: partner-dashboard
+ms.subservice:  partnercenter-csp
+ms.localizationpriority: medium
+---
+
+# Get transfer details by id
+
+Applies to:
+
+- Partner Center
+- Partner Center operated by 21Vianet
+- Partner Center for Microsoft Cloud Germany
+- Partner Center for Microsoft Cloud for US Government
+
+
+## Prerequisites
+
+- Credentials as described in [Partner Center authentication](partner-center-authentication.md). This scenario supports authentication with both standalone App and App+User credentials.
+- A customer identifier. If you do not have a customer's ID, you can look up the ID in Partner Center by choosing the customer from the customers list, selecting Account, then saving their Microsoft ID.
+- A transfer identifier for an existing transfer.
+
+## REST request
+
+### Request syntax
+
+| Method   | Request URI                                                                                                 |
+|----------|-------------------------------------------------------------------------------------------------------------|
+| **GET** | [*{baseURL}*](partner-center-rest-urls.md)/v1/customers/{customer-id}/transfers/{transfer-id} HTTP/1.1                    |
+
+### URI parameter
+
+Use the following path parameter to identify the customer and specify the transfer to be accepted.
+
+| Name            | Type     | Required | Description                                                            |
+|-----------------|----------|----------|------------------------------------------------------------------------|
+| **customer-id** | string   | Yes      | A GUID formatted customer-id that identifies the customer.             |
+| **transfer-id** | string   | Yes      | A GUID formatted transfer-id that identifies the transfer.             |
+
+### Request headers
+
+See [Partner Center REST headers](headers.md) for more information.
+
+
+### Request example
+
+```http
+GET /v1/customers/b67f0b00-f9e8-4c57-bcb5-0b8b95c6ccf0/transfers/46e8ed67-8adf-4f65-b3d8-d31318080556 HTTP/1.1
+Authorization: Bearer <token>
+Connection: keep-alive
+MS-RequestId: 0d61b5ce-b396-4f5e-a50b-e8779d0d23cc
+MS-CorrelationId: 68eacc61-971c-43b0-c06f-2622bf79b090
+Accept: application/json
+```
+
+## REST response
+
+If successful, this method returns the populated [TransferEntity](transfer-resources.md) resource in the response body.
+
+### Response success and error codes
+
+Each response comes with an HTTP status code that indicates success or failure and additional debugging information. Use a network trace tool to read this code, error type, and additional parameters. For the full list, see [Error Codes](error-codes.md).
+
+### Response example
+
+```http
+HTTP/1.1 200 OK
+Content-Length: 1501
+Content-Type: application/json; charset=utf-8
+MS-CorrelationId: 68eacc61-971c-43b0-c06f-2622bf79b090
+MS-RequestId: 0d61b5ce-b396-4f5e-a50b-e8779d0d23cc
+X-Locale: en-US
+Date: Fri, 27 Mar 2020 18:25:25 GMT
+
+{
+  "id": "46e8ed67-8adf-4f65-b3d8-d31318080556",
+  "status": "Active",
+  "createdTime": "2020-03-27T18:22:33.2875302Z",
+  "lastModifiedTime": "2020-03-27T18:22:33Z",
+  "customerTenantId": "b67f0b00-f9e8-4c57-bcb5-0b8b95c6ccf0",
+  "partnertenantid": "3a9a35ce-d5be-4814-ab58-4451c36fe157",
+  "sourcePartnerName": "Test_Test_09092019GBL",
+  "sourcePartnerTenantId": "7c8db11f-1e5e-4472-8386-f0b627d1f3e1",
+  "targetPartnerName": "Test_Test_09032019GBL",
+  "targetPartnerTenantId": "3a9a35ce-d5be-4814-ab58-4451c36fe157",
+  "lastModifiedUser": "edc0524d-2e42-4619-af7e-349c015cfdfd",
+  "lineItems": [
+    {
+      "id": 0,
+      "subscriptionId": "75B71186-73C3-45B4-A403-281C0D7EB032",
+      "offerId": "F72752C8-3E37-4C9B-A1A0-69E8442068DC",
+      "billingCycle": "annual",
+      "friendlyName": "Dynamics 365 Business Central Team Member",
+      "quantity": 1,
+      "partnerIdOnRecord": "5139005",
+      "addonItems": [
+        
+      ]
+    },
+    {
+      "id": 1,
+      "subscriptionId": "1FB4CB0A-EB79-4300-9E87-7D486054888A",
+      "offerId": "88F9EB8A-0636-45E8-A601-553E0A48AA9E",
+      "billingCycle": "annual",
+      "friendlyName": "Dynamics 365 Business Central External Accountant",
+      "quantity": 1,
+      "partnerIdOnRecord": "5139005",
+      "addonItems": [
+        
+      ]
+    },
+    {
+      "id": 2,
+      "subscriptionId": "08AB3010-B647-402E-8955-B6C0FB364D8F",
+      "offerId": "4D8F3B90-29B3-4E7B-B37C-4A435DDEF1D9",
+      "billingCycle": "annual",
+      "friendlyName": "Common Area Phone",
+      "quantity": 1,
+      "partnerIdOnRecord": "5139005",
+      "addonItems": [
+        
+      ]
+    }
+  ],
+  "links": {
+    "self": {
+      "uri": "/customers/b67f0b00-f9e8-4c57-bcb5-0b8b95c6ccf0/transfers/46e8ed67-8adf-4f65-b3d8-d31318080556",
+      "method": "GET",
+      "headers": [
+        
+      ]
+    }
+  },
+  "attributes": {
+    "objectType": "TransferEntity"
+  }
+}
+
+```

--- a/develop/reject-a-transfer.md
+++ b/develop/reject-a-transfer.md
@@ -1,0 +1,129 @@
+---
+title: Reject a transfer
+description: How to reject a transfer of subscriptions for a customer.
+ms.date: 04/03/2020
+ms.service: partner-dashboard
+ms.subservice:  partnercenter-csp
+ms.localizationpriority: medium
+---
+
+# Reject a transfer
+
+Applies to:
+
+- Partner Center
+- Partner Center operated by 21Vianet
+- Partner Center for Microsoft Cloud Germany
+- Partner Center for Microsoft Cloud for US Government
+
+
+## Prerequisites
+
+- Credentials as described in [Partner Center authentication](partner-center-authentication.md). This scenario supports authentication with both standalone App and App+User credentials.
+- A customer identifier. If you do not have a customer's ID, you can look up the ID in Partner Center by choosing the customer from the customers list, selecting Account, then saving their Microsoft ID.
+- A transfer identifier for an existing transfer.
+
+## REST request
+
+### Request syntax
+
+| Method   | Request URI                                                                                                 |
+|----------|-------------------------------------------------------------------------------------------------------------|
+| **PATCH** | [*{baseURL}*](partner-center-rest-urls.md)/v1/customers/{customer-id}/transfers/{transfer-id} HTTP/1.1                    |
+
+### URI parameter
+
+Use the following path parameter to identify the customer and specify the transfer to be accepted.
+
+| Name            | Type     | Required | Description                                                            |
+|-----------------|----------|----------|------------------------------------------------------------------------|
+| **customer-id** | string   | Yes      | A GUID formatted customer-id that identifies the customer.             |
+| **transfer-id** | string   | Yes      | A GUID formatted transfer-id that identifies the transfer.             |
+
+### Request headers
+
+See [Partner Center REST headers](headers.md) for more information.
+
+### Request body
+
+This table describes the [TransferEntity](transfer-resources.md) properties in the request body.
+
+| Property              | Type          | Required  | Description                                                                                |
+|-----------------------|---------------|-----------|--------------------------------------------------------------------------------------------|
+| id                    | string        | No    | A transferEntity identifier that is supplied upon successful creation of the transferEntity.                               |
+| status                | string        | No    | The status of the transferEntity. To reject a transfer, the value is to be set as "reject"|
+
+### Request example
+
+```http
+PATCH /v1/customers/b67f0b00-f9e8-4c57-bcb5-0b8b95c6ccf0/transfers/ac4a9d22-ba07-444e-890f-cfe084eed498 HTTP/1.1
+Authorization: Bearer <token>
+Accept: application/json
+MS-CorrelationId: efa4c6f5-153a-4f76-e458-1375e181cc14
+MS-RequestId: 5b46e795-b661-428e-a2e7-f208b8d0d25c
+Connection: keep-alive
+Content-Length: 63
+
+{"id":"ac4a9d22-ba07-444e-890f-cfe084eed498","status":"reject"}
+
+```
+
+## REST response
+
+If successful, this method returns the populated [TransferEntity](transfer-resources.md) resource in the response body.
+
+### Response success and error codes
+
+Each response comes with an HTTP status code that indicates success or failure and additional debugging information. Use a network trace tool to read this code, error type, and additional parameters. For the full list, see [Error Codes](error-codes.md).
+
+### Response example
+
+```http
+HTTP/1.1 200 OK
+Content-Length: 1069
+Content-Type: application/json; charset=utf-8
+MS-CorrelationId: efa4c6f5-153a-4f76-e458-1375e181cc14
+MS-RequestId: 5b46e795-b661-428e-a2e7-f208b8d0d25c
+X-Locale: en-US
+Date: Fri, 27 Mar 2020 17:50:33 GMT
+
+{
+  "id": "ac4a9d22-ba07-444e-890f-cfe084eed498",
+  "status": "Reject",
+  "createdTime": "2020-03-25T22:05:25.1057725Z",
+  "lastModifiedTime": "2020-03-27T17:50:32Z",
+  "customerTenantId": "b67f0b00-f9e8-4c57-bcb5-0b8b95c6ccf0",
+  "partnertenantid": "3a9a35ce-d5be-4814-ab58-4451c36fe157",
+  "sourcePartnerName": "Test_Test_09092019GBL",
+  "sourcePartnerTenantId": "7c8db11f-1e5e-4472-8386-f0b627d1f3e1",
+  "targetPartnerName": "Test_Test_09032019GBL",
+  "targetPartnerTenantId": "3a9a35ce-d5be-4814-ab58-4451c36fe157",
+  "lastModifiedUser": "01a7548d-1136-4cf0-ba9a-300f921ffb22",
+  "lineItems": [
+    {
+      "id": 0,
+      "subscriptionId": "1151B8CE-125C-49D7-8C48-E62FC9101B77",
+      "offerId": "13D32E13-A1B0-400D-96C0-4EAAA14DCED5",
+      "billingCycle": "monthly",
+      "friendlyName": "Dynamics 365 for Supply Chain Management Attach to Qualifying Dynamics 365 Base Offer (Qualified Offer)",
+      "quantity": 20,
+      "partnerIdOnRecord": "5139005",
+      "addonItems": [
+        
+      ]
+    }
+  ],
+  "links": {
+    "self": {
+      "uri": "/customers/b67f0b00-f9e8-4c57-bcb5-0b8b95c6ccf0/transfers/ac4a9d22-ba07-444e-890f-cfe084eed498",
+      "method": "GET",
+      "headers": [
+        
+      ]
+    }
+  },
+  "attributes": {
+    "objectType": "TransferEntity"
+  }
+}
+```

--- a/develop/transfer-eligibility-resources.md
+++ b/develop/transfer-eligibility-resources.md
@@ -1,0 +1,29 @@
+---
+title: TransferEligibility resources
+description: A partner creates a transfer when a customer wants his subscription with the partner to be transferred to another partner.
+ms.date: 04/03/2020
+ms.service: partner-dashboard
+ms.subservice:  partnercenter-csp
+ms.localizationpriority: medium
+---
+
+# TransferEligibility resources
+
+Applies to:
+
+- Partner Center
+- Partner Center operated by 21Vianet
+- Partner Center for Microsoft Cloud Germany
+- Partner Center for Microsoft Cloud for US Government
+
+A partner creates a transfer when a customer wants his subscription with the partner to be transferred to another partner.
+
+## TransferEligibility
+
+Describes a transferEligibility.
+
+| Property              | Type             | Description                                                                              |
+|-----------------------|------------------|------------------------------------------------------------------------------------------|
+| id                    | string           | The customer's subscription identifier.                                                  |
+| isEligible            | bool             | Indicates whether the subscription is eligible for the transfer.                         |
+| Reason                | string           | The reason explaining the ineligiblity if the subscription is not eligible for transfer. |

--- a/develop/transfer-entity-resources.md
+++ b/develop/transfer-entity-resources.md
@@ -1,0 +1,95 @@
+---
+title: TransferEntity resources
+description: A partner creates a transfer when a customer wants his subscription with the partner to be transferred to another partner.
+ms.date: 04/03/2020
+ms.service: partner-dashboard
+ms.subservice:  partnercenter-csp
+ms.localizationpriority: medium
+---
+
+# TransferEntity resources
+
+Applies to:
+
+- Partner Center
+- Partner Center operated by 21Vianet
+- Partner Center for Microsoft Cloud Germany
+- Partner Center for Microsoft Cloud for US Government
+
+A partner creates a transfer when a customer wants his subscription with the partner to be transferred to another partner.
+
+## TransferEntity
+
+Describes a transferEntity.
+
+| Property              | Type             | Description                                                                                            |
+|-----------------------|------------------|--------------------------------------------------------------------------------------------------------|
+| id                    | string           | A transferEntity identifier that is supplied upon successful creation of the transferEntity.                               |
+| createdTime           | DateTime         | The date the transferEntity was created, in date-time format. Applied upon successful creation of the transferEntity.      |
+| lastModifiedTime      | DateTime         | The date the transferEntity was last updated, in date-time format. Applied upon successful creation of the transferEntity. |
+| lastModifiedUser      | string           | The user who last updated the transferEntity. Applied upon successful creation of transferEntity.                          |
+| customerName          | string           | Optional. The name of the customer whose subscriptions are being transferred.                                              |
+| customerTenantId      | string           | A GUID formatted customer-id that identifies the customer. Applied upon successful creation of the transferEntity.         |
+| partnertenantid       | string           | A GUID formatted partner-id that identifies the partner.                                                                   |
+| sourcePartnerName     | string           | Optional. The name of the partner's organization who is initiating the transfer.                                           |
+| sourcePartnerTenantId | string           | A GUID formatted partner-id that identifies the partner initiating the transfer.                                           |
+| targetPartnerName     | string           | Optional. The name of the partner's organization to whom the transfer is targeted.                                         |
+| targetPartnerTenantId | string           | A GUID formatted partner-id that identifies the partner to whom the transfer is targeted.                                  |
+| lineItems             | Array of objects | An Array of [TransferLineItem](#transferlineitem) resources.                                                   |
+| status                | string           | The status of the transferEntity. Possible values are "Active" (can be deleted/submitted) and "Completed" (has already been completed). Applied upon successful creation of the transferEntity.|
+
+## TransferLineItem
+
+Represents one item contained in a transferEntity.
+
+| Property             | Type                             | Description                                                                                             |
+|----------------------|----------------------------------|---------------------------------------------------------------------------------------------------------|
+| id                   | string                           | A unique identifier for a transfer line item. Applied upon successful creation of the transferEntity.   |
+| subscriptionId       | string                           | The subscription identifier.                                                                            |
+| quantity             | int                              | The number of licenses or instances.                                                                    |
+| billingCycle         | Object                           | The type of billing cycle set for the current period.                                                   |
+| friendlyName         | string                           | Optional. The friendly name for the item defined by the partner to help disambiguate.                   |
+| partnerIdOnRecord    | string                           | PartnerId on Record (MPNID) on the purchase that happens when the transfer is accepted.                 |
+| offerId              | string                           | The offer identifier.    |
+| addonItems           | List of **TransferLineItem** objects | A collection of transferEntity line items for addons that will be transferred along with the base subscription that is being transferred. Applied upon successful creation of the transferEntity.|
+| transferError        | string                           | Applied after transferEntity is accepted in case of an error.                |
+| status               | string           | The status of the lineitem in the transferEntity.|
+
+## TransferSubmitResult
+
+Represents the result of a transfer accept.
+
+| Property          | Type                                                  | Description                        |
+|-------------------|-------------------------------------------------------|------------------------------------|
+| orders            | List of [Order](order-resources.md#order) objects.    | The collection of orders.          |
+| transferErrors    | List of [TransferError](#transfererror) objects.      | The collection of transfer errors. |
+
+## TransferError
+
+Represents an error that occurs when a transfer is accepted.
+
+| Property          | Type   | Description                                     |
+|-------------------|--------|-------------------------------------------------|
+| transferGroupId   | string | The order group ID of the order with the error. |
+| code              | int    | The error code.                                 |
+| description       | string | The description of the error.                   |
+| lineItems         | List of **TransferLineItem** objects | A collection of transferEntity line items that are part of the transfer error.|
+
+## TransferErrorCode
+
+An [Enum](https://docs.microsoft.com/dotnet/api/system.enum) with values that indicate a type of order error.
+
+| Value | Position | Description |
+| --- | --- | --- |
+| PartnerTokenMissing | 800001 | Partner Token missing in request context. |
+| InvalidInput | 800002 | Invalid request input. |
+| ServiceException | 800003 | Unexpected service error. |
+| InvalidOfferId | 800004 | Invalid offer ID. |
+| CreateOrderError | 800005 | Create order is not successful. |
+| MpnIdNotFound | 800015 | MPN Id is not found. |
+| NotValidIndirectResellerMpnId | 800016 | MPN Id is not a valid Indirect Reseller. |
+| TransferIdNotFound | 900100   | Transfer request not found.   |
+| TransferNotAllowedIfStatusIsInProgress | 900101 | The transfer request is already in progress.|
+| TransferNotAllowedIfStatusIsCompleted | 900102 | The transfer request is already complete.|
+| TransferCreateOrderError | 900103 | The transfer order is not successful.|
+| TransferProcessedByAnotherRequest | 900104 | The transfer is being processed by another request.|

--- a/develop/withdraw-a-transfer.md
+++ b/develop/withdraw-a-transfer.md
@@ -1,0 +1,75 @@
+---
+title: Withdraw a transfer
+description: How to withdraw a created transfer of subscriptions for a customer.
+ms.date: 04/03/2020
+ms.service: partner-dashboard
+ms.subservice:  partnercenter-csp
+ms.localizationpriority: medium
+---
+
+# Withdraw a transfer
+
+Applies to:
+
+- Partner Center
+- Partner Center operated by 21Vianet
+- Partner Center for Microsoft Cloud Germany
+- Partner Center for Microsoft Cloud for US Government
+
+
+## Prerequisites
+
+- Credentials as described in [Partner Center authentication](partner-center-authentication.md). This scenario supports authentication with both standalone App and App+User credentials.
+- A customer identifier. If you do not have a customer's ID, you can look up the ID in Partner Center by choosing the customer from the customers list, selecting Account, then saving their Microsoft ID.
+- A transfer identifier for an existing transfer.
+
+## REST request
+
+### Request syntax
+
+| Method    | Request URI                                                                                                 |
+|-----------|-------------------------------------------------------------------------------------------------------------|
+| **DELETE**| [*{baseURL}*](partner-center-rest-urls.md)/v1/customers/{customer-id}/transfers/{transfer-id} HTTP/1.1      |
+
+### URI parameter
+
+Use the following path parameter to identify the customer.
+
+| Name            | Type     | Required | Description                                                            |
+|-----------------|----------|----------|------------------------------------------------------------------------|
+| **customer-id** | string   | Yes      | A GUID formatted customer-id that identifies the customer.             |
+| **transfer-id** | string   | Yes      | A GUID formatted transfer-id that identifies the transfer.             |
+
+### Request headers
+
+See [Partner Center REST headers](headers.md) for more information.
+
+
+### Request example
+
+```http
+DELETE /v1/customers/d6bf25b7-e0a8-4f2d-a31b-97b55cfc774d/transfers/67c5b05b-09b5-47ba-9047-5056fe2afa4f HTTP/1.1
+Authorization: Bearer <token>
+Accept: application/json
+MS-RequestId: cdf6e25c-7b32-4cc3-d8bc-53e0b37eebd8
+MS-CorrelationId: 9041d76d-8915-43a8-8e82-00ca46a1a73d
+Connection: keep-alive
+```
+
+## REST response
+
+If successful, this method returns No Content (204).
+
+### Response success and error codes
+
+Each response comes with an HTTP status code that indicates success or failure and additional debugging information. Use a network trace tool to read this code, error type, and additional parameters. For the full list, see [Error Codes](error-codes.md).
+
+### Response example
+
+```http
+HTTP/1.1 204 No Content
+Content-Length: 0
+MS-CorrelationId: 9041d76d-8915-43a8-8e82-00ca46a1a73d
+MS-RequestId: cdf6e25c-7b32-4cc3-d8bc-53e0b37eebd8
+Date: Tue, 24 Mar 2020 23:44:06 GMT
+```


### PR DESCRIPTION
Direct to Indirect transfers that support transfer of subscriptions from a direct partner that is transitioning to be a indirect reseller to Indirect provider is now supported through UI. To support the corresponding APIs, the work is in progress, the documentation is to support the said APIs.