### PR TITLE
fix typo

### DIFF
--- a/develop/get-a-list-of-skus-for-a-product.md
+++ b/develop/get-a-list-of-skus-for-a-product.md
@@ -92,7 +92,7 @@ To get the list of SKUs for a product:
 # $targetSegment
 
 # Get the available SKUs.
-Get-PartnerProductSku -ProudctId $productId
+Get-PartnerProductSku -ProductId $productId
 
 # Get the available SKUs, filtered by target segment.
 Get-PartnerProductSku -ProductId $productId -Segment $targetSegment


### PR DESCRIPTION
When I copied the example it threw an error as there is a typo in the param name.